### PR TITLE
Use std::string and std::wstring

### DIFF
--- a/include/Lucene.h
+++ b/include/Lucene.h
@@ -55,12 +55,12 @@ namespace boost
 
 namespace Lucene
 {
-    typedef std::basic_string< char, std::char_traits<char>, Allocator<char> > SingleString;
-    typedef std::basic_ostringstream< char, std::char_traits<char>, Allocator<char> > SingleStringStream;
-    typedef std::basic_string< wchar_t, std::char_traits<wchar_t>, Allocator<wchar_t> > String;
-    typedef std::basic_ostringstream< wchar_t, std::char_traits<wchar_t>, Allocator<wchar_t> > StringStream;
-    
-    const std::basic_string< wchar_t, std::char_traits<wchar_t>, Allocator<wchar_t> > EmptyString;
+	typedef std::string SingleString;
+	typedef std::ostringstream SingleStringStream;
+	typedef std::wstring String;
+	typedef std::wostringstream StringStream;
+
+	const String EmptyString;
     
     typedef boost::shared_ptr<boost::interprocess::file_lock> filelockPtr;
     typedef boost::shared_ptr<boost::thread> threadPtr;


### PR DESCRIPTION
Referring to my posts on the Google Groups mailing lists, here's the patch to make the Lucene::String types a bit more compatible with at least our project under Xcode 4.2, and save some of the repeated construction and c_str()'ing.

I should note that std::string (and std::wstring, and anything else that derives from std::basic_string<_>) is implemented as a ref-counted copy-on-write wrapper internally for nearly all C++ standard library implementations - meaning that having the host code repeatedly getting the (w)char_ from the .c_str() function and constructing a new object is going to be a lot more expensive with _any_ allocator, especially when dealing with stack-allocated temporaries.

--- commit message ---
The custom allocator specifications otherwise make Lucene::String and Lucene::SingleString incompatible with common string types used by a host program; forcing repeated reconstruction via constructing one type with the .c_str() of the other.

The custom allocator was disabled by default, a thin wrapper around malloc/free.

Non-standard types need non-standard support in debuggers; an especially painful problem with current versions of Xcode 4.2, which seem to have broken custom debug data formatters.
