### PR TITLE
Remove outdated note about Boost incompatibility from the README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,11 +38,6 @@ On Debian systems, the following packages are required:
 - libboost-iostreams-dev
 - libboost-test-dev
 
-.. note::
-
-   At present, you must use Boost 1.49 or older. There is an incompatibility
-   to Boost 1.50 and newer that causes ``make`` to fail. See `issue #30`__.
-
 __ https://github.com/luceneplusplus/LucenePlusPlus/issues/30
 
 To build the library the following commands should be issued::


### PR DESCRIPTION
Commit e3f8992 ported the code to use Boost.Filesystem V3 API,
so the warning about not being able to use Boost 1.50+ is no longer true.
