### PR TITLE
Fix races when initializing static arrays in StandardTokenizerImpl

### DIFF
--- a/include/StandardTokenizerImpl.h
+++ b/include/StandardTokenizerImpl.h
@@ -32,6 +32,7 @@ namespace Lucene
         static const int32_t ZZ_CMAP_PACKED_LENGTH;
         
         /// Translates characters to character classes
+        static void ZZ_CMAP_INIT(CharArray& zz_action);
         static const wchar_t* ZZ_CMAP();
         
         /// Translates DFA states to action switch labels.
@@ -40,6 +41,7 @@ namespace Lucene
         static const int32_t ZZ_ACTION_PACKED_LENGTH;
         
         /// Translates DFA states to action switch labels.
+        static void ZZ_ACTION_INIT(IntArray& zz_action);
         static const int32_t* ZZ_ACTION();
         
         /// Translates a state to a row index in the transition table
@@ -48,6 +50,7 @@ namespace Lucene
         static const int32_t ZZ_ROWMAP_PACKED_LENGTH;
         
         /// Translates a state to a row index in the transition table
+        static void ZZ_ROWMAP_INIT(IntArray& zz_rowmap);
         static const int32_t* ZZ_ROWMAP();
         
         /// The transition table of the DFA
@@ -56,6 +59,7 @@ namespace Lucene
         static const int32_t ZZ_TRANS_PACKED_LENGTH;
         
         /// The transition table of the DFA
+        static void ZZ_TRANS_INIT(IntArray& zz_trans);
         static const int32_t* ZZ_TRANS();
         
         // error codes
@@ -71,6 +75,7 @@ namespace Lucene
         static const int32_t ZZ_ATTRIBUTE_PACKED_LENGTH;
         
         /// ZZ_ATTRIBUTE[aState] contains the attributes of state aState
+        static void ZZ_ATTRIBUTE_INIT(IntArray& zz_attribute);
         static const int32_t* ZZ_ATTRIBUTE();
         
         /// The input device

--- a/src/core/analysis/standard/StandardTokenizerImpl.cpp
+++ b/src/core/analysis/standard/StandardTokenizerImpl.cpp
@@ -4,6 +4,8 @@
 // or the GNU Lesser General Public License.
 /////////////////////////////////////////////////////////////////////////////
 
+#include <boost/thread/once.hpp>
+
 #include "LuceneInc.h"
 #include "StandardTokenizerImpl.h"
 #include "StandardTokenizer.h"
@@ -202,112 +204,127 @@ namespace Lucene
     StandardTokenizerImpl::~StandardTokenizerImpl()
     {
     }
+
+    void StandardTokenizerImpl::ZZ_CMAP_INIT(CharArray& zz_cmap)
+    {
+        zz_cmap = CharArray::newInstance(ZZ_CMAP_LENGTH);
+        wchar_t* result = zz_cmap.get();
     
+        int32_t i = 0; // index in packed string
+        int32_t j = 0; // index in unpacked array
+        while (i < ZZ_CMAP_PACKED_LENGTH)
+        {
+            int32_t count = ZZ_CMAP_PACKED[i++];
+            wchar_t value = ZZ_CMAP_PACKED[i++];
+            do
+                result[j++] = value;
+            while (--count > 0);
+        }
+    }
+
     const wchar_t* StandardTokenizerImpl::ZZ_CMAP()
     {
+        static boost::once_flag once = BOOST_ONCE_INIT;
         static CharArray _ZZ_CMAP;
-        if (!_ZZ_CMAP)
-        {
-            _ZZ_CMAP = CharArray::newInstance(ZZ_CMAP_LENGTH);
-            wchar_t* result = _ZZ_CMAP.get();
-            
-            int32_t i = 0; // index in packed string
-            int32_t j = 0; // index in unpacked array
-            while (i < ZZ_CMAP_PACKED_LENGTH)
-            {
-                int32_t count = ZZ_CMAP_PACKED[i++];
-                wchar_t value = ZZ_CMAP_PACKED[i++];
-                do
-                    result[j++] = value;
-                while (--count > 0);
-            }
-        }
+        boost::call_once(once, ZZ_CMAP_INIT, _ZZ_CMAP);
         return _ZZ_CMAP.get();
+    }
+
+    void StandardTokenizerImpl::ZZ_ACTION_INIT(IntArray& zz_action)
+    {
+        zz_action = IntArray::newInstance(ZZ_ACTION_LENGTH);
+        int32_t* result = zz_action.get();
+
+        int32_t i = 0; // index in packed string
+        int32_t j = 0; // index in unpacked array
+        while (i < ZZ_ACTION_PACKED_LENGTH)
+        {
+            int32_t count = ZZ_ACTION_PACKED_0[i++];
+            int32_t value = ZZ_ACTION_PACKED_0[i++];
+            do
+                result[j++] = value;
+            while (--count > 0);
+        }
     }
     
     const int32_t* StandardTokenizerImpl::ZZ_ACTION()
     {
+        static boost::once_flag once = BOOST_ONCE_INIT;
         static IntArray _ZZ_ACTION;
-        if (!_ZZ_ACTION)
-        {
-            _ZZ_ACTION = IntArray::newInstance(ZZ_ACTION_LENGTH);
-            int32_t* result = _ZZ_ACTION.get();
-            
-            int32_t i = 0; // index in packed string
-            int32_t j = 0; // index in unpacked array
-            while (i < ZZ_ACTION_PACKED_LENGTH)
-            {
-                int32_t count = ZZ_ACTION_PACKED_0[i++];
-                int32_t value = ZZ_ACTION_PACKED_0[i++];
-                do
-                    result[j++] = value;
-                while (--count > 0);
-            }
-        }
+        boost::call_once(once, ZZ_ACTION_INIT, _ZZ_ACTION);
         return _ZZ_ACTION.get();
     }
-    
-    const  int32_t* StandardTokenizerImpl::ZZ_ROWMAP()
+
+    void StandardTokenizerImpl::ZZ_ROWMAP_INIT(IntArray& zz_rowmap)
+    {
+        zz_rowmap = IntArray::newInstance(ZZ_ROWMAP_LENGTH);
+        int32_t* result = zz_rowmap.get();
+
+        int32_t i = 0; // index in packed string
+        int32_t j = 0; // index in unpacked array
+        while (i < ZZ_ROWMAP_PACKED_LENGTH)
+        {
+            int32_t high = ZZ_ROWMAP_PACKED_0[i++] << 16;
+            result[j++] = high | ZZ_ROWMAP_PACKED_0[i++];
+        }
+    }
+
+    const int32_t* StandardTokenizerImpl::ZZ_ROWMAP()
     {
         static IntArray _ZZ_ROWMAP;
-        if (!_ZZ_ROWMAP)
-        {
-            _ZZ_ROWMAP = IntArray::newInstance(ZZ_ROWMAP_LENGTH);
-            int32_t* result = _ZZ_ROWMAP.get();
-            
-            int32_t i = 0; // index in packed string
-            int32_t j = 0; // index in unpacked array
-            while (i < ZZ_ROWMAP_PACKED_LENGTH)
-            {
-                int32_t high = ZZ_ROWMAP_PACKED_0[i++] << 16;
-                result[j++] = high | ZZ_ROWMAP_PACKED_0[i++];
-            }
-        }
+        static boost::once_flag once = BOOST_ONCE_INIT;
+        boost:call_once(once, ZZ_ROWMAP_INIT, _ZZ_ROWMAP);
         return _ZZ_ROWMAP.get();
+    }
+
+    void StandardTokenizerImpl::ZZ_TRANS_INIT(IntArray& zz_trans)
+    {
+        zz_trans = IntArray::newInstance(ZZ_TRANS_LENGTH);
+        int32_t* result = zz_trans.get();
+
+        int32_t i = 0; // index in packed string
+        int32_t j = 0; // index in unpacked array
+        while (i < ZZ_TRANS_PACKED_LENGTH)
+        {
+            int32_t count = ZZ_TRANS_PACKED_0[i++];
+            int32_t value = ZZ_TRANS_PACKED_0[i++];
+            --value;
+            do
+                result[j++] = value;
+            while (--count > 0);
+        }    
     }
     
     const int32_t* StandardTokenizerImpl::ZZ_TRANS()
     {
+        static boost::once_flag once = BOOST_ONCE_INIT;
         static IntArray _ZZ_TRANS;
-        if (!_ZZ_TRANS)
-        {
-            _ZZ_TRANS = IntArray::newInstance(ZZ_TRANS_LENGTH);
-            int32_t* result = _ZZ_TRANS.get();
-            
-            int32_t i = 0; // index in packed string
-            int32_t j = 0; // index in unpacked array
-            while (i < ZZ_TRANS_PACKED_LENGTH)
-            {
-                int32_t count = ZZ_TRANS_PACKED_0[i++];
-                int32_t value = ZZ_TRANS_PACKED_0[i++];
-                --value;
-                do
-                    result[j++] = value;
-                while (--count > 0);
-            }
-        }
+        boost::call_once(once, ZZ_TRANS_INIT, _ZZ_TRANS);
         return _ZZ_TRANS.get();
     }
-    
+
+    void StandardTokenizerImpl::ZZ_ATTRIBUTE_INIT(IntArray& zz_attribute)
+    {
+        zz_attribute = IntArray::newInstance(ZZ_ATTRIBUTE_LENGTH);
+        int32_t* result = zz_attribute.get();
+
+        int32_t i = 0; // index in packed string
+        int32_t j = 0; // index in unpacked array
+        while (i < ZZ_ATTRIBUTE_PACKED_LENGTH)
+        {
+            int32_t count = ZZ_ATTRIBUTE_PACKED_0[i++];
+            int32_t value = ZZ_ATTRIBUTE_PACKED_0[i++];
+            do
+                result[j++] = value;
+            while (--count > 0);
+        }
+    }
+
     const int32_t* StandardTokenizerImpl::ZZ_ATTRIBUTE()
     {
+        static boost::once_flag once = BOOST_ONCE_INIT;
         static IntArray _ZZ_ATTRIBUTE;
-        if (!_ZZ_ATTRIBUTE)
-        {
-            _ZZ_ATTRIBUTE = IntArray::newInstance(ZZ_ATTRIBUTE_LENGTH);
-            int32_t* result = _ZZ_ATTRIBUTE.get();
-            
-            int32_t i = 0; // index in packed string
-            int32_t j = 0; // index in unpacked array
-            while (i < ZZ_ATTRIBUTE_PACKED_LENGTH)
-            {
-                int32_t count = ZZ_ATTRIBUTE_PACKED_0[i++];
-                int32_t value = ZZ_ATTRIBUTE_PACKED_0[i++];
-                do
-                    result[j++] = value;
-                while (--count > 0);
-            }
-        }
+        boost::call_once(once, ZZ_ATTRIBUTE_INIT, _ZZ_ATTRIBUTE);
         return _ZZ_ATTRIBUTE.get();
     }
     


### PR DESCRIPTION
I've observed crashes where one thread is in the middle of initializing
ZZ_CMAP and other is trying to use the partially initialized array and
crashes.
Use boost::once to ensure that only one thread handles the initialization
and no thread uses the data until it is fully initialized.
