### PR TITLE
Compilation fixes for C++11 compilers.

### DIFF
--- a/include/Array.h
+++ b/include/Array.h
@@ -119,7 +119,7 @@ namespace Lucene
         
         operator bool () const
         {
-            return container;
+            return container != NULL;
         }
         
         bool operator! () const

--- a/include/AttributeSource.h
+++ b/include/AttributeSource.h
@@ -95,7 +95,7 @@ namespace Lucene
         template <class ATTR>
         bool hasAttribute()
         {
-            return getAttribute(ATTR::_getClassName());
+            return getAttribute(ATTR::_getClassName()) != NULL;
         }
         
         /// Returns the instance of the passed in Attribute contained in this AttributeSource.

--- a/include/Collection.h
+++ b/include/Collection.h
@@ -211,7 +211,7 @@ namespace Lucene
 
         operator bool() const
         {
-            return container;
+            return container != NULL;
         }
 
         bool operator! () const

--- a/include/HashMap.h
+++ b/include/HashMap.h
@@ -82,7 +82,7 @@ namespace Lucene
 
         operator bool() const
         {
-            return mapContainer;
+            return mapContainer != NULL;
         }
 
         bool operator! () const

--- a/include/HashSet.h
+++ b/include/HashSet.h
@@ -88,7 +88,7 @@ namespace Lucene
 
         operator bool() const
         {
-            return setContainer;
+            return setContainer != NULL;
         }
 
         bool operator! () const

--- a/include/Map.h
+++ b/include/Map.h
@@ -82,7 +82,7 @@ namespace Lucene
 
         operator bool() const
         {
-            return mapContainer;
+            return mapContainer != NULL;
         }
 
         bool operator! () const

--- a/include/MiscUtils.h
+++ b/include/MiscUtils.h
@@ -125,7 +125,7 @@ namespace Lucene
         template <typename TYPE>
         static bool typeOf(LuceneObjectPtr object)
         {
-            return boost::dynamic_pointer_cast<TYPE>(object);
+            return boost::dynamic_pointer_cast<TYPE>(object) != NULL;
         }
         
         /// Return whether given Lucene objects are of equal type.

--- a/include/Set.h
+++ b/include/Set.h
@@ -132,7 +132,7 @@ namespace Lucene
 
         operator bool() const
         {
-            return setContainer;
+            return setContainer != NULL;
         }
 
         bool operator! () const

--- a/src/core/include/_FieldCacheRangeFilter.h
+++ b/src/core/include/_FieldCacheRangeFilter.h
@@ -146,7 +146,7 @@ namespace Lucene
                 return false;
             if (lowerVal != otherFilter->lowerVal || upperVal != otherFilter->upperVal)
                 return false;
-            if (parser ? !parser->equals(otherFilter->parser) : otherFilter->parser)
+            if (parser ? !parser->equals(otherFilter->parser) : (otherFilter->parser != NULL))
                 return false;
             return true;
         }

--- a/src/core/index/DirectoryReader.cpp
+++ b/src/core/index/DirectoryReader.cpp
@@ -976,7 +976,7 @@ namespace Lucene
             
             SegmentMergeInfoPtr smi(newLucene<SegmentMergeInfo>(starts[i], termEnum, reader));
             smi->ord = i;
-            if (t ? termEnum->term() : smi->next())
+            if (t ? (termEnum->term() != NULL) : smi->next())
                 queue->add(smi); // initialize queue
             else
                 smi->close();

--- a/src/core/index/IndexWriter.cpp
+++ b/src/core/index/IndexWriter.cpp
@@ -687,7 +687,7 @@ namespace Lucene
     
     bool IndexWriter::verbose()
     {
-        return infoStream;
+        return infoStream != NULL;
     }
     
     void IndexWriter::setWriteLockTimeout(int64_t writeLockTimeout)

--- a/src/core/index/MultiLevelSkipListReader.cpp
+++ b/src/core/index/MultiLevelSkipListReader.cpp
@@ -27,7 +27,7 @@ namespace Lucene
         this->maxNumberOfSkipLevels = maxSkipLevels;
         this->skipInterval = Collection<int32_t>::newInstance(maxSkipLevels);
         this->skipStream[0] = skipStream;
-        this->inputIsBuffered = boost::dynamic_pointer_cast<BufferedIndexInput>(skipStream);
+        this->inputIsBuffered = boost::dynamic_pointer_cast<BufferedIndexInput>(skipStream) != NULL;
         this->skipInterval[0] = skipInterval;
         this->skipDoc = Collection<int32_t>::newInstance(maxSkipLevels);
 

--- a/src/core/index/SegmentReader.cpp
+++ b/src/core/index/SegmentReader.cpp
@@ -376,7 +376,7 @@ namespace Lucene
     bool SegmentReader::hasDeletions()
     {
         // Don't call ensureOpen() here (it could affect performance)
-        return deletedDocs;
+        return deletedDocs != NULL;
     }
     
     bool SegmentReader::usesCompoundFile(SegmentInfoPtr si)
@@ -923,7 +923,7 @@ namespace Lucene
     bool CoreReaders::termsIndexIsLoaded()
     {
         SyncLock syncLock(this);
-        return tis;
+        return tis != NULL;
     }
     
     void CoreReaders::loadTermsIndex(SegmentInfoPtr si, int32_t termsIndexDivisor)

--- a/src/core/search/FieldCacheRangeFilter.cpp
+++ b/src/core/search/FieldCacheRangeFilter.cpp
@@ -170,7 +170,7 @@ namespace Lucene
             return false;
         if (lowerVal != otherFilter->lowerVal || upperVal != otherFilter->upperVal)
             return false;
-        if (parser ? !parser->equals(otherFilter->parser) : otherFilter->parser)
+        if (parser ? !parser->equals(otherFilter->parser) : (otherFilter->parser != NULL))
             return false;
         return true;
     }

--- a/src/core/search/Query.cpp
+++ b/src/core/search/Query.cpp
@@ -73,7 +73,7 @@ namespace Lucene
             Collection<BooleanClausePtr> clauses;
             BooleanQueryPtr bq(boost::dynamic_pointer_cast<BooleanQuery>(*query));
             // check if we can split the query into clauses
-            bool splittable = bq;
+            bool splittable = bq != NULL;
             if (splittable)
             {
                 splittable = bq->isCoordDisabled();

--- a/src/core/store/NativeFSLockFactory.cpp
+++ b/src/core/store/NativeFSLockFactory.cpp
@@ -79,7 +79,7 @@ namespace Lucene
     bool NativeFSLock::lockExists()
     {
         SyncLock syncLock(this);
-        return lock;
+        return lock != NULL;
     }
     
     bool NativeFSLock::obtain()


### PR DESCRIPTION
boost::shared_ptr has explicit operator bool() with C++11 compilers (in particular, Visual Studio 2013 which is C++11 by default) since 1.53 (see http://www.boost.org/users/history/version_1_53_0.html).
Explicit != NULL check needs to be used instead.

See also http://stackoverflow.com/questions/15234527/boost-1-53-local-date-time-compiler-error-with-std-c0x
