### PR TITLE
Fix incorrect paths handling on Windows.

### DIFF
--- a/include/InfoStream.h
+++ b/include/InfoStream.h
@@ -8,7 +8,7 @@
 #define INFOSTREAM_H
 
 #include "LuceneObject.h"
-#include <fstream>
+#include <boost/filesystem/fstream.hpp>
 
 namespace Lucene
 {
@@ -36,7 +36,7 @@ namespace Lucene
         LUCENE_CLASS(InfoStreamFile);
             
     protected:
-        std::wofstream file;
+        boost::filesystem::wofstream file;
     
     public:
         virtual InfoStreamFile& operator<< (const String& t);

--- a/include/Lucene.h
+++ b/include/Lucene.h
@@ -19,6 +19,7 @@
 #include <stdexcept>
 
 #include <boost/cstdint.hpp>
+#include <boost/filesystem/fstream.hpp>
 #include <boost/variant.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/weak_ptr.hpp>
@@ -65,8 +66,8 @@ namespace Lucene
     typedef boost::shared_ptr<boost::interprocess::file_lock> filelockPtr;
     typedef boost::shared_ptr<boost::thread> threadPtr;
 
-    typedef boost::shared_ptr<std::ofstream> ofstreamPtr;
-    typedef boost::shared_ptr<std::ifstream> ifstreamPtr;
+    typedef boost::shared_ptr<boost::filesystem::ofstream> ofstreamPtr;
+    typedef boost::shared_ptr<boost::filesystem::ifstream> ifstreamPtr;
     typedef boost::shared_ptr<std::locale> localePtr;
 }
 

--- a/src/core/index/IndexReader.cpp
+++ b/src/core/index/IndexReader.cpp
@@ -5,7 +5,7 @@
 /////////////////////////////////////////////////////////////////////////////
 
 #include "LuceneInc.h"
-#include <fstream>
+#include <boost/filesystem/fstream.hpp>
 #include <iostream>
 #include "IndexReader.h"
 #include "_IndexReader.h"
@@ -383,8 +383,8 @@ namespace Lucene
                 {
                     std::wcout << L"extract " << *file << L" with " << len << L" bytes to local directory...";
                     IndexInputPtr ii(cfr->openInput(*file));
-                    
-                    std::ofstream f(StringUtils::toUTF8(*file).c_str(), std::ios::binary | std::ios::out);
+
+                    boost::filesystem::ofstream f(*file, std::ios::binary | std::ios::out);
                     
                     // read and write with a small buffer, which is more effective than reading byte by byte
                     ByteArray buffer(ByteArray::newInstance(1024));

--- a/src/core/store/FSDirectory.cpp
+++ b/src/core/store/FSDirectory.cpp
@@ -5,7 +5,7 @@
 /////////////////////////////////////////////////////////////////////////////
 
 #include "LuceneInc.h"
-#include <fstream>
+#include <boost/filesystem/fstream.hpp>
 #include "FSDirectory.h"
 #include "NativeFSLockFactory.h"
 #include "SimpleFSDirectory.h"
@@ -158,10 +158,10 @@ namespace Lucene
         
         for (int32_t retryCount = 0; retryCount < 5; ++retryCount)
         {
-            std::ofstream syncFile;
+            boost::filesystem::ofstream syncFile;
             try
             {
-                syncFile.open(StringUtils::toUTF8(path).c_str(), std::ios::binary | std::ios::in | std::ios::out);
+                syncFile.open(path, std::ios::binary | std::ios::in | std::ios::out);
             }
             catch (...)
             {

--- a/src/core/store/MMapDirectory.cpp
+++ b/src/core/store/MMapDirectory.cpp
@@ -43,7 +43,7 @@ namespace Lucene
         {
             try
             {
-                file.open(StringUtils::toUTF8(path).c_str(), _length);
+                file.open(boost::filesystem::wpath(path), _length);
             }
             catch (...)
             {

--- a/src/core/store/SimpleFSDirectory.cpp
+++ b/src/core/store/SimpleFSDirectory.cpp
@@ -5,7 +5,7 @@
 /////////////////////////////////////////////////////////////////////////////
 
 #include "LuceneInc.h"
-#include <fstream>
+#include <boost/filesystem/fstream.hpp>
 #include "SimpleFSDirectory.h"
 #include "_SimpleFSDirectory.h"
 #include "IndexOutput.h"
@@ -45,7 +45,7 @@ namespace Lucene
     
     InputFile::InputFile(const String& path)
     {
-        file = newInstance<std::ifstream>(StringUtils::toUTF8(path).c_str(), std::ios::binary | std::ios::in);
+        file = newInstance<boost::filesystem::ifstream>(path, std::ios::binary | std::ios::in);
         if (!file->is_open())
             boost::throw_exception(FileNotFoundException(path));
         position = 0;
@@ -175,7 +175,7 @@ namespace Lucene
     OutputFile::OutputFile(const String& path)
     {
         this->path = path;
-        file = newInstance<std::ofstream>(StringUtils::toUTF8(path).c_str(), std::ios::binary | std::ios::out);
+        file = newInstance<boost::filesystem::ofstream>(path, std::ios::binary | std::ios::out);
     }
     
     OutputFile::~OutputFile()

--- a/src/core/store/SimpleFSLockFactory.cpp
+++ b/src/core/store/SimpleFSLockFactory.cpp
@@ -5,7 +5,7 @@
 /////////////////////////////////////////////////////////////////////////////
 
 #include "LuceneInc.h"
-#include <fstream>
+#include <boost/filesystem/fstream.hpp>
 #include "SimpleFSLockFactory.h"
 #include "_SimpleFSLockFactory.h"
 #include "FileUtils.h"
@@ -61,10 +61,10 @@ namespace Lucene
         }
         else if (!FileUtils::isDirectory(lockDir))
             boost::throw_exception(RuntimeException(L"Found regular file where directory expected: " + lockDir));
-        std::ofstream f;
+        boost::filesystem::ofstream f;
         try
         {
-            f.open(StringUtils::toUTF8(FileUtils::joinPath(lockDir, lockFile)).c_str(), std::ios::binary | std::ios::out);
+            f.open(FileUtils::joinPath(lockDir, lockFile), std::ios::binary | std::ios::out);
         }
         catch (...)
         {

--- a/src/core/util/FileReader.cpp
+++ b/src/core/util/FileReader.cpp
@@ -5,7 +5,7 @@
 /////////////////////////////////////////////////////////////////////////////
 
 #include "LuceneInc.h"
-#include <fstream>
+#include <boost/filesystem/fstream.hpp>
 #include "FileReader.h"
 #include "MiscUtils.h"
 #include "FileUtils.h"
@@ -18,7 +18,7 @@ namespace Lucene
     
     FileReader::FileReader(const String& fileName)
     {
-        this->file = newInstance<std::ifstream>(StringUtils::toUTF8(fileName).c_str(), std::ios::binary | std::ios::in);
+        this->file = newInstance<boost::filesystem::ifstream>(fileName, std::ios::binary | std::ios::in);
         if (!file->is_open())
             boost::throw_exception(FileNotFoundException(fileName));
         _length = FileUtils::fileLength(fileName);

--- a/src/core/util/FileUtils.cpp
+++ b/src/core/util/FileUtils.cpp
@@ -89,7 +89,7 @@ namespace Lucene
                 int32_t fd = _wopen(path.c_str(), _O_WRONLY | _O_CREAT | _O_BINARY, _S_IWRITE);
                 return _chsize(fd, (long)length) == 0;
                 #else
-                return truncate(StringUtils::toUTF8(path).c_str(), (off_t)length) == 0;
+                return truncate(boost::filesystem::path(path).c_str(), (off_t)length) == 0;
                 #endif
             }
             catch (...)

--- a/src/core/util/InfoStream.cpp
+++ b/src/core/util/InfoStream.cpp
@@ -19,7 +19,7 @@ namespace Lucene
     {
     }
     
-    InfoStreamFile::InfoStreamFile(const String& path) : file(StringUtils::toUTF8(path).c_str())
+    InfoStreamFile::InfoStreamFile(const String& path) : file(path)
     {
     }
     


### PR DESCRIPTION
Lucene++ keeps paths around as wide strings, but uses narrow char APIs (e.g.
std::ifstream) when accessing files, using conversion to UTF-8 to get char*
strings. This is correct on OS X and usually(!) correct on modern Unix systems,
but is completely wrong on Windows, which _never_ uses UTF-8 for filenames.

Fix this using boost::filesystem classes (path and streams) and appropriate
conversions. In one place, use a Windows-specific workaround to deal with lack
of wide char boost API.

In particular:
- Use boost::filesystem::*fstream classes that accept Unicode paths.
- Use boost::filesystem::(w)path for manual conversion when needed.
- When using char\* only API (interprocess::file_lock), use GetShortPathName()
  as a workaround.

Practical consequences of this incorrect handling were severe: it was impossible to store Lucene index in a directory with non-ASCII characters in it (such as the user's home directory!).
