### PR TITLE
Release version 3.0.5.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Lucene++
 ==========
 
-Welcome to lucene++ version **3.0.4**.
+Welcome to lucene++ version **3.0.5**.
 
 Lucene++ is an up to date C++ port of the popular Java `Lucene <http://lucene.apache.org/>`_ library, a high-performance, full-featured text search engine.
 

--- a/doxygen/lucene++
+++ b/doxygen/lucene++
@@ -31,7 +31,7 @@ PROJECT_NAME           = Lucene++
 # This could be handy for archiving the generated documentation or
 # if some version control system is used.
 
-PROJECT_NUMBER         = 3.0.4
+PROJECT_NUMBER         = 3.0.5
 
 # The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute)
 # base path where the generated documentation will be put.

--- a/scripts/llvm/wscript
+++ b/scripts/llvm/wscript
@@ -14,7 +14,7 @@ from TaskGen import feature, after
 #import Task, ccroot
 
 APPNAME='Lucene++'
-VERSION='3.0.2'
+VERSION='3.0.5'
 
 top = '../../'
 out = 'bin'

--- a/src/core/util/Constants.cpp
+++ b/src/core/util/Constants.cpp
@@ -21,8 +21,8 @@ namespace Lucene
     String Constants::OS_NAME = L"BSD";
     #endif
     
-    String Constants::LUCENE_MAIN_VERSION = L"3.0.3.4";
-    String Constants::LUCENE_VERSION = L"3.0.3";
+    String Constants::LUCENE_MAIN_VERSION = L"3.0.5";
+    String Constants::LUCENE_VERSION = L"3.0.5";
     
     Constants::Constants()
     {

--- a/wscript
+++ b/wscript
@@ -13,7 +13,7 @@ from TaskGen import feature, after
 import Task
 
 APPNAME='Lucene++'
-VERSION='3.0.4.0'
+VERSION='3.0.5'
 
 top = '.'
 out = 'bin'


### PR DESCRIPTION
Would it be possible to tag a new 3.0.5 release, mostly for the benefit of Linux distributions? There were some useful fixes since 3.0.4 and some API changes (65c63d0 in particular introduces interoperability with std::wstring and code relying on it won't compile with 3.0.4).

I replaced all occurrences of old version numbers (not just 3.0.4, some were out of sync) in this commit to make doing a release as easy as possible. I _think_ I got the versioning right ("3.0.5" vs "3.0.5.0"), judging from both (Java) Lucene and previous commits in the history, but if I didn't and it should be 3.0.5.0 (or even different values in different places), just let me know and I'll gladly update the PR.
