### PR TITLE
Complete quoting for parameters of some CMake commands.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,12 +105,12 @@ endif()
 # generate Config.h
 #################################
 configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/include/Config.h.cmake
-  ${CMAKE_CURRENT_BINARY_DIR}/include/Config.h @ONLY
+  "${CMAKE_CURRENT_SOURCE_DIR}/include/Config.h.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}/include/Config.h" @ONLY
 )
 
 include_directories(
-  ${CMAKE_CURRENT_BINARY_DIR}/include
+  "${CMAKE_CURRENT_BINARY_DIR}/include"
 )
 
 include(CMakeExternal.txt)
@@ -126,16 +126,16 @@ add_subdirectory(src/test)
 #################################
 if(NOT WIN32)
   configure_file(
-    ${CMAKE_CURRENT_SOURCE_DIR}/liblucene++.pc.cmake
-    ${CMAKE_CURRENT_BINARY_DIR}/liblucene++.pc @ONLY)
+    "${CMAKE_CURRENT_SOURCE_DIR}/liblucene++.pc.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/liblucene++.pc" @ONLY)
   configure_file(
-    ${CMAKE_CURRENT_SOURCE_DIR}/liblucene++-contrib.pc.cmake
-    ${CMAKE_CURRENT_BINARY_DIR}/liblucene++-contrib.pc @ONLY)
+    "${CMAKE_CURRENT_SOURCE_DIR}/liblucene++-contrib.pc.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/liblucene++-contrib.pc" @ONLY)
   install(
     FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/liblucene++.pc
-    ${CMAKE_CURRENT_BINARY_DIR}/liblucene++-contrib.pc
-    DESTINATION ${LIB_DESTINATION}/pkgconfig)
+    "${CMAKE_CURRENT_BINARY_DIR}/liblucene++.pc"
+    "${CMAKE_CURRENT_BINARY_DIR}/liblucene++-contrib.pc"
+    DESTINATION "${LIB_DESTINATION}/pkgconfig")
 endif()
 
 ####################################
@@ -150,6 +150,7 @@ configure_file(
 add_custom_target(
   uninstall
   "${CMAKE_COMMAND}" -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+  VERBATIM
 )
 
 if(ENABLE_PACKAGING)

--- a/cmake/CreateLucene++Packages.cmake
+++ b/cmake/CreateLucene++Packages.cmake
@@ -39,7 +39,7 @@ set(CPACK_RPM_PACKAGE_GROUP "libs")
 set(CPACK_RPM_PACKAGE_REQUIRES "libboost-date-time1.42.0, libboost-filesystem1.42.0, libboost-regex1.42.0, libboost-thread1.42.0, libboost-iostreams1.42.0")
 
 #don't include the current binary dir.
-get_filename_component(lucene++_BINARY_DIR_name ${lucene++_BINARY_DIR} NAME)
+get_filename_component(lucene++_BINARY_DIR_name "${lucene++_BINARY_DIR}" NAME)
 set(CPACK_SOURCE_IGNORE_FILES
   "/\\\\.svn/"
   "/\\\\.git/"
@@ -70,11 +70,11 @@ endif()
 
 
 add_custom_target(dist-package
-    COMMAND rsync -avP -e ssh ${CPACK_PACKAGE_FILE_NAME}.* ustramooner@frs.sourceforge.net:uploads/
+    COMMAND rsync -avP -e ssh "${CPACK_PACKAGE_FILE_NAME}.*" ustramooner@frs.sourceforge.net:uploads/
 #    DEPENDS package
 )
 add_custom_target(dist-package_source
-    COMMAND rsync -avP -e ssh ${CPACK_SOURCE_PACKAGE_FILE_NAME}.* ustramooner@frs.sourceforge.net:uploads/
+    COMMAND rsync -avP -e ssh "${CPACK_SOURCE_PACKAGE_FILE_NAME}.*" ustramooner@frs.sourceforge.net:uploads/
 #    DEPENDS package_source
 )
 

--- a/cmake/Lucene++Docs.cmake
+++ b/cmake/Lucene++Docs.cmake
@@ -62,7 +62,8 @@ IF (ENABLE_DOCS)
         # It runs the final generated Doxyfile against it.
         # The DOT_PATH is substituted into the Doxyfile.
         ADD_CUSTOM_TARGET(doc
-            ${DOXYGEN_EXECUTABLE} ${PROJECT_BINARY_DIR}/doc/doxyfile
+            "${DOXYGEN_EXECUTABLE}" "${PROJECT_BINARY_DIR}/doc/doxyfile"
+            VERBATIM
         )
 
         IF ( DOCS_HTML_HELP )
@@ -78,11 +79,11 @@ IF (ENABLE_DOCS)
             IF ( CYGWIN )
                 EXECUTE_PROCESS ( COMMAND cygpath "${HTML_HELP_COMPILER}"
                     OUTPUT_VARIABLE HTML_HELP_COMPILER_EX )
-                STRING ( REPLACE "\n" "" HTML_HELP_COMPILER_EX ${HTML_HELP_COMPILER_EX} )
-                STRING ( REPLACE "\r" "" HTML_HELP_COMPILER_EX ${HTML_HELP_COMPILER_EX} )
+                STRING ( REPLACE "\n" "" HTML_HELP_COMPILER_EX "${HTML_HELP_COMPILER_EX}" )
+                STRING ( REPLACE "\r" "" HTML_HELP_COMPILER_EX "${HTML_HELP_COMPILER_EX}" )
                 SET ( HTML_HELP_COMPILER_EX "\"${HTML_HELP_COMPILER_EX}\"" )
             ELSE ( CYGWIN )
-                SET ( HTML_HELP_COMPILER_EX ${HTML_HELP_COMPILER} )
+                SET ( HTML_HELP_COMPILER_EX "${HTML_HELP_COMPILER}" )
             ENDIF ( CYGWIN )
         ENDIF ( DOCS_HTML_HELP )
 
@@ -123,10 +124,10 @@ IF (ENABLE_DOCS)
         ENDIF ( DOCS_TAGFILE )
 
         # This processes our Doxyfile.cmake and substitutes paths to generate a final Doxyfile
-        CONFIGURE_FILE(${PROJECT_SOURCE_DIR}/doc/Doxyfile.cmake ${PROJECT_BINARY_DIR}/doc/doxyfile )
-        CONFIGURE_FILE(${PROJECT_SOURCE_DIR}/doc/helpheader.htm.cmake ${PROJECT_BINARY_DIR}/doc/helpheader.htm )
-        CONFIGURE_FILE(${PROJECT_SOURCE_DIR}/doc/helpfooter.htm.cmake ${PROJECT_BINARY_DIR}/doc/helpfooter.htm )
-        CONFIGURE_FILE(${PROJECT_SOURCE_DIR}/doc/doxygen.css.cmake ${PROJECT_BINARY_DIR}/doc/html/doxygen.css )
+        CONFIGURE_FILE("${PROJECT_SOURCE_DIR}/doc/Doxyfile.cmake" "${PROJECT_BINARY_DIR}/doc/doxyfile")
+        CONFIGURE_FILE("${PROJECT_SOURCE_DIR}/doc/helpheader.htm.cmake" "${PROJECT_BINARY_DIR}/doc/helpheader.htm")
+        CONFIGURE_FILE("${PROJECT_SOURCE_DIR}/doc/helpfooter.htm.cmake" "${PROJECT_BINARY_DIR}/doc/helpfooter.htm")
+        CONFIGURE_FILE("${PROJECT_SOURCE_DIR}/doc/doxygen.css.cmake" "${PROJECT_BINARY_DIR}/doc/html/doxygen.css")
 
         #create a target for tar.gz html help
         FIND_PACKAGE(UnixCommands)
@@ -135,17 +136,18 @@ IF (ENABLE_DOCS)
                 COMMAND "${TAR}" "-czf" "${PROJECT_BINARY_DIR}/doc/lucene++-doc.tar.gz" ./
                 WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/doc/html/"
                 #DEPENDS doc
+                VERBATIM
             )
         ENDIF ( TAR AND GZIP )
 
 	#install HTML pages if they were built
 	IF ( DOCS_HTML AND NOT WIN32 )
-            INSTALL(DIRECTORY ${PROJECT_BINARY_DIR}/doc/html/ DESTINATION share/doc/lucene++-${lucene++_VERSION})
+            INSTALL(DIRECTORY "${PROJECT_BINARY_DIR}/doc/html/" DESTINATION share/doc/lucene++-${lucene++_VERSION})
         ENDIF ( DOCS_HTML AND NOT WIN32 )
 
         #install man pages if they were built
         IF ( DOCS_MAN )
-            INSTALL(DIRECTORY ${PROJECT_BINARY_DIR}/doc/man/ DESTINATION man)
+            INSTALL(DIRECTORY "${PROJECT_BINARY_DIR}/doc/man/" DESTINATION man)
         ENDIF ( DOCS_MAN )
 
     ELSE ( DOXYGEN_FOUND )

--- a/src/contrib/CMakeLists.txt
+++ b/src/contrib/CMakeLists.txt
@@ -11,16 +11,16 @@ file(GLOB_RECURSE contrib_sources
 )
 
 file(GLOB_RECURSE contrib_headers
-  ${lucene++-contrib_SOURCE_DIR}/include/*.h
+  "${lucene++-contrib_SOURCE_DIR}/include/*.h"
 )
 
 add_definitions(-DLPP_BUILDING_LIB)
 
 include_directories(
-  ${lucene++_SOURCE_DIR}/include
-  ${lucene++-lib_SOURCE_DIR}/include
-  ${lucene++-contrib_SOURCE_DIR}/include
-  ${lucene++-contrib_SOURCE_DIR}/snowball/libstemmer_c/include
+  "${lucene++_SOURCE_DIR}/include"
+  "${lucene++-lib_SOURCE_DIR}/include"
+  "${lucene++-contrib_SOURCE_DIR}/include"
+  "${lucene++-contrib_SOURCE_DIR}/snowball/libstemmer_c/include"
   ${Boost_INCLUDE_DIRS}
 )
 
@@ -53,6 +53,6 @@ target_link_libraries(lucene++-contrib
 cotire(lucene++-contrib)
 
 install(TARGETS lucene++-contrib
-  DESTINATION ${LIB_DESTINATION}
+  DESTINATION "${LIB_DESTINATION}"
   COMPONENT runtime
 )

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,8 +1,8 @@
 project(lucene++-lib)
 
 include_directories(
-  ${lucene++_SOURCE_DIR}/include
-  ${lucene++-lib_SOURCE_DIR}/include
+  "${lucene++_SOURCE_DIR}/include"
+  "${lucene++-lib_SOURCE_DIR}/include"
   ${Boost_INCLUDE_DIRS}
 )
 
@@ -16,7 +16,7 @@ file(GLOB_RECURSE lucene_sources
   util/*.c*)
 
 file(GLOB_RECURSE lucene_internal_headers
-  ${lucene++-lib_SOURCE_DIR}/include/*.h
+  "${lucene++-lib_SOURCE_DIR}/include/*.h"
 )
 
 file(GLOB_RECURSE lucene_headers
@@ -49,6 +49,6 @@ install(FILES ${lucene_headers}
 )
 
 install(TARGETS lucene++
-  DESTINATION ${LIB_DESTINATION}
+  DESTINATION "${LIB_DESTINATION}"
   COMPONENT runtime
 )

--- a/src/demo/CMakeLists.txt
+++ b/src/demo/CMakeLists.txt
@@ -2,7 +2,7 @@ project(lucene++-demo)
 
 file(GLOB_RECURSE
   demo_headers
-  ${lucene++-demo_SOURCE_DIR}/../include/*.h
+  "${lucene++-demo_SOURCE_DIR}/../include/*.h"
 )
 
 add_definitions(-DLPP_HAVE_DLL)
@@ -11,11 +11,11 @@ include_directories(
   ${Boost_INCLUDE_DIRS}
 )
 include_directories(
-  ${lucene++_SOURCE_DIR}/include
+  "${lucene++_SOURCE_DIR}/include"
 )
 
 add_executable(indexfiles
-  ${lucene++-demo_SOURCE_DIR}/indexfiles/main.cpp
+  "${lucene++-demo_SOURCE_DIR}/indexfiles/main.cpp"
   ${demo_headers}
 )
 target_link_libraries(indexfiles
@@ -23,7 +23,7 @@ target_link_libraries(indexfiles
 )
 
 add_executable(searchfiles
-  ${lucene++-demo_SOURCE_DIR}/searchfiles/main.cpp
+  "${lucene++-demo_SOURCE_DIR}/searchfiles/main.cpp"
   ${demo_headers}
 )
 target_link_libraries(searchfiles
@@ -31,7 +31,7 @@ target_link_libraries(searchfiles
 )
 
 add_executable(deletefiles
-  ${lucene++-demo_SOURCE_DIR}/deletefiles/main.cpp
+  "${lucene++-demo_SOURCE_DIR}/deletefiles/main.cpp"
   ${demo_headers}
 )
 target_link_libraries(deletefiles

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1,11 +1,11 @@
 project(lucene++-tester)
 
 include_directories(
-  ${GTEST_INCLUDE_DIR}
-  ${lucene++_SOURCE_DIR}/include
-  ${lucene++-lib_SOURCE_DIR}/include
-  ${lucene++-contrib_SOURCE_DIR}/include
-  ${lucene++-tester_SOURCE_DIR}/include
+  "${GTEST_INCLUDE_DIR}"
+  "${lucene++_SOURCE_DIR}/include"
+  "${lucene++-lib_SOURCE_DIR}/include"
+  "${lucene++-contrib_SOURCE_DIR}/include"
+  "${lucene++-tester_SOURCE_DIR}/include"
   ${Boost_INCLUDE_DIRS}
 )
 
@@ -22,14 +22,14 @@ file(GLOB_RECURSE tester_sources
 )
 
 file(GLOB_RECURSE test_headers
-  ${lucene++-tester_SOURCE_DIR}/../include/*.h
-  ${lucene++-tester_SOURCE_DIR}/include/*.h
+  "${lucene++-tester_SOURCE_DIR}/../include/*.h"
+  "${lucene++-tester_SOURCE_DIR}/include/*.h"
 )
 
 add_definitions(-DLPP_EXPOSE_INTERNAL)
 
 link_directories(
-  ${GTEST_LIB_DIR}
+  "${GTEST_LIB_DIR}"
 )
 
 add_executable(lucene++-tester


### PR DESCRIPTION
[A wiki article pointed out](http://cmake.org/Wiki/CMake/Language_Syntax#CMake_splits_arguments_unless_you_use_quotation_marks_or_escapes.) that whitespace will only be preserved for parameters in CMake commands if passed strings will be appropriately quoted or escaped.

Quoting can be added so that more places should also handle file names correctly which contain space characters or semicolons eventually.
