### PR TITLE
Fix various compiler warnings.

### DIFF
--- a/include/Array.h
+++ b/include/Array.h
@@ -15,9 +15,9 @@ namespace Lucene {
 template <typename TYPE>
 class ArrayData {
 public:
-    ArrayData(int32_t size) {
+    ArrayData(int32_t size_) {
         data = NULL;
-        resize(size);
+        resize(size_);
     }
 
     ~ArrayData() {
@@ -29,16 +29,16 @@ public:
     int32_t size;
 
 public:
-    void resize(int32_t size) {
-        if (size == 0) {
+    void resize(int32_t size_) {
+        if (size_ == 0) {
             FreeMemory(data);
             data = NULL;
         } else if (data == NULL) {
-            data = (TYPE*)AllocMemory(size * sizeof(TYPE));
+            data = (TYPE*)AllocMemory(size_ * sizeof(TYPE));
         } else {
-            data = (TYPE*)ReallocMemory(data, size * sizeof(TYPE));
+            data = (TYPE*)ReallocMemory(data, size_ * sizeof(TYPE));
         }
-        this->size = size;
+        this->size = size_;
     }
 };
 

--- a/include/Fieldable.h
+++ b/include/Fieldable.h
@@ -20,6 +20,7 @@ namespace Lucene {
 class LPPAPI Fieldable {
 public:
     LUCENE_INTERFACE(Fieldable);
+    virtual ~Fieldable() {}
 
 public:
     /// Sets the boost factor hits on this field.  This value will be multiplied into the score of all

--- a/include/Searchable.h
+++ b/include/Searchable.h
@@ -24,6 +24,7 @@ namespace Lucene {
 class LPPAPI Searchable {
 public:
     LUCENE_INTERFACE(Searchable);
+    virtual ~Searchable() {}
 
 public:
     /// Lower-level search API.

--- a/include/SegmentInfoCollection.h
+++ b/include/SegmentInfoCollection.h
@@ -29,7 +29,7 @@ public:
     void add(const SegmentInfoPtr& info);
     void add(int32_t pos, const SegmentInfoPtr& info);
     void addAll(const SegmentInfoCollectionPtr& segmentInfos);
-    bool equals(const SegmentInfoCollectionPtr& other);
+    bool equals(const LuceneObjectPtr& other);
     int32_t find(const SegmentInfoPtr& info);
     bool contains(const SegmentInfoPtr& info);
     void remove(int32_t pos);

--- a/src/core/index/SegmentInfoCollection.cpp
+++ b/src/core/index/SegmentInfoCollection.cpp
@@ -41,11 +41,17 @@ void SegmentInfoCollection::addAll(const SegmentInfoCollectionPtr& segmentInfos)
     this->segmentInfos.addAll(segmentInfos->segmentInfos.begin(), segmentInfos->segmentInfos.end());
 }
 
-bool SegmentInfoCollection::equals(const SegmentInfoCollectionPtr& other) {
+bool SegmentInfoCollection::equals(const LuceneObjectPtr& other) {
     if (LuceneObject::equals(other)) {
         return true;
     }
-    return segmentInfos.equals(other->segmentInfos, luceneEquals<SegmentInfoPtr>());
+
+    SegmentInfoCollectionPtr otherColl(boost::dynamic_pointer_cast<SegmentInfoCollection>(other));
+    if (!otherColl) {
+        return false;
+    }
+
+    return segmentInfos.equals(otherColl->segmentInfos, luceneEquals<SegmentInfoPtr>());
 }
 
 int32_t SegmentInfoCollection::find(const SegmentInfoPtr& info) {


### PR DESCRIPTION
Fix various warnings produced by Clang:

Array.h:32:25: Declaration shadows a field of 'ArrayData<TYPE>'
SegmentInfoCollection.h:32:10: 'Lucene::SegmentInfoCollection::equals' hides overloaded virtual function
Searchable.h:24:14: 'Lucene::Searchable' has virtual functions but non-virtual destructor
Fieldable.h:20:14: 'Lucene::Fieldable' has virtual functions but non-virtual destructor

(a8bac06c4c4997310633c8ff13952d28b1c67593 helped a lot with warnings, these remaining few are shown when including Lucene headers from other code)
