### PR TITLE
Fix NumericTokenStream::setDoubleValue() to use correct encoding.

### DIFF
--- a/src/core/analysis/NumericTokenStream.cpp
+++ b/src/core/analysis/NumericTokenStream.cpp
@@ -87,7 +87,7 @@ NumericTokenStreamPtr NumericTokenStream::setIntValue(int32_t value) {
 }
 
 NumericTokenStreamPtr NumericTokenStream::setDoubleValue(double value) {
-    this->value = (int64_t)value;
+    this->value = NumericUtils::doubleToSortableLong(value);
     valSize = 64;
     shift = 0;
     return shared_from_this();


### PR DESCRIPTION
The code used a simple cast to `int64_t`, which truncated the value and made searching with decimal precision impossible.  Moreover, the encoding was different from what `NumericRangeQuery` expected and search results were wrong in other situations as well.

Fix by using `NumericUtils::doubleToSortableLong()`, as both `NumericRangeQuery` and the original Java code do.
