### PR TITLE
Moved Subversion requirement outside CMakeLists

### DIFF
--- a/CMakeExternal.txt
+++ b/CMakeExternal.txt
@@ -1,5 +1,6 @@
 # Enable ExternalProject CMake module
 include(ExternalProject)
+find_package(Subversion REQUIRED)
 
 # main directory for external projects
 set_directory_properties(PROPERTIES EP_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/ThirdParty)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,6 @@ option(ENABLE_CYCLIC_CHECK
 # bootstrap
 ####################################
 
-find_package(Subversion REQUIRED)
 find_package(Threads REQUIRED)
 find_package(Boost COMPONENTS
   date_time


### PR DESCRIPTION
I really would like to don't have subversion required when building on debian buildd.
