### PR TITLE
Moving into -doc directory, the best location for a doxygen documentation directory

### DIFF
--- a/cmake/Lucene++Docs.cmake
+++ b/cmake/Lucene++Docs.cmake
@@ -142,7 +142,7 @@ IF (ENABLE_DOCS)
 
 	#install HTML pages if they were built
 	IF ( DOCS_HTML AND NOT WIN32 )
-            INSTALL(DIRECTORY "${PROJECT_BINARY_DIR}/doc/html/" DESTINATION share/doc/lucene++/html)
+            INSTALL(DIRECTORY "${PROJECT_BINARY_DIR}/doc/html/" DESTINATION share/doc/lucene++-doc/html)
         ENDIF ( DOCS_HTML AND NOT WIN32 )
 
         #install man pages if they were built


### PR DESCRIPTION
Sorry but looking at the directory I think this is the more standard way to install it
