### PR TITLE
fixed build on mingw

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -34,6 +34,10 @@ target_link_libraries(lucene++
   ${lucene_boost_libs}
 )
 
+if(WIN32)
+    target_link_libraries(lucene++ ws2_32)
+endif()
+
 set_target_properties(lucene++ PROPERTIES COTIRE_CXX_PREFIX_HEADER_INIT "include/LuceneInc.h")
 cotire(lucene++)
 


### PR DESCRIPTION
 the automatic linking of the boost dependencies using #pragma comment(lib, "ws2_32") doesn't work with mingw
