### PR TITLE
Don't throw exceptions in file operations just to ignore them.

### DIFF
--- a/src/core/util/FileUtils.cpp
+++ b/src/core/util/FileUtils.cpp
@@ -25,159 +25,116 @@ namespace Lucene {
 namespace FileUtils {
 
 bool fileExists(const String& path) {
-    try {
-        return boost::filesystem::exists(path.c_str());
-    } catch (...) {
-        return false;
-    }
+    boost::system::error_code ec;
+    return boost::filesystem::exists(path.c_str(), ec);
 }
 
 uint64_t fileModified(const String& path) {
-    try {
-        return (uint64_t)boost::filesystem::last_write_time(path.c_str());
-    } catch (...) {
-        return 0;
-    }
+    boost::system::error_code ec;
+    uint64_t t = (uint64_t)boost::filesystem::last_write_time(path.c_str(), ec);
+    return ec ? 0 : t;
 }
 
 bool touchFile(const String& path) {
-    try {
-        boost::filesystem::last_write_time(path.c_str(), time(NULL));
-        return true;
-    } catch (...) {
-        return false;
-    }
+    boost::system::error_code ec;
+    boost::filesystem::last_write_time(path.c_str(), time(NULL), ec);
+    return !ec;
 }
 
 int64_t fileLength(const String& path) {
-    try {
-        int64_t fileSize = (int64_t)boost::filesystem::file_size(path.c_str());
-        for (int32_t i = 0; fileSize == 0 && i < 100; ++i) {
-            LuceneThread::threadYield();
-            fileSize = (int64_t)boost::filesystem::file_size(path.c_str());
-        }
-        return fileSize;
-    } catch (...) {
-        return 0;
+    boost::system::error_code ec;
+    int64_t fileSize = (int64_t)boost::filesystem::file_size(path.c_str(), ec);
+    for (int32_t i = 0; !ec && fileSize == 0 && i < 100; ++i) {
+        LuceneThread::threadYield();
+        fileSize = (int64_t)boost::filesystem::file_size(path.c_str(), ec);
     }
+
+    return ec ? 0 : fileSize;
 }
 
 bool setFileLength(const String& path, int64_t length) {
-    try {
-        if (!fileExists(path)) {
-            return false;
-        }
-#if defined(_WIN32) || defined(_WIN64)
-        int32_t fd = _wopen(path.c_str(), _O_WRONLY | _O_CREAT | _O_BINARY, _S_IWRITE);
-        return _chsize(fd, (long)length) == 0;
-#else
-        return truncate(boost::filesystem::path(path).c_str(), (off_t)length) == 0;
-#endif
-    } catch (...) {
+    if (!fileExists(path)) {
         return false;
     }
+#if defined(_WIN32) || defined(_WIN64)
+    int32_t fd = _wopen(path.c_str(), _O_WRONLY | _O_CREAT | _O_BINARY, _S_IWRITE);
+    return _chsize(fd, (long)length) == 0;
+#else
+    return truncate(boost::filesystem::path(path).c_str(), (off_t)length) == 0;
+#endif
 }
 
 bool removeFile(const String& path) {
-    try {
-        return boost::filesystem::remove(path.c_str());
-    } catch (...) {
-        return false;
-    }
+    boost::system::error_code ec;
+    return boost::filesystem::remove(path.c_str(), ec);
 }
 
 bool copyFile(const String& source, const String& dest) {
-    try {
-        boost::filesystem::copy_file(source.c_str(), dest.c_str());
-        return true;
-    } catch (...) {
-        return false;
-    }
+    boost::system::error_code ec;
+    boost::filesystem::copy_file(source.c_str(), dest.c_str(), ec);
+    return !ec;
 }
 
 bool createDirectory(const String& path) {
-    try {
-        return boost::filesystem::create_directory(path.c_str());
-    } catch (...) {
-        return false;
-    }
+    boost::system::error_code ec;
+    return boost::filesystem::create_directory(path.c_str(), ec) && !ec;
 }
 
 bool removeDirectory(const String& path) {
-    try {
-        boost::filesystem::remove_all(path.c_str());
-        return true;
-    } catch (...) {
-        return false;
-    }
+    boost::system::error_code ec;
+    boost::filesystem::remove_all(path.c_str(), ec);
+    return !ec;
 }
 
 bool isDirectory(const String& path) {
-    try {
-        return boost::filesystem::is_directory(path.c_str());
-    } catch (...) {
-        return false;
-    }
+    boost::system::error_code ec;
+    return boost::filesystem::is_directory(path.c_str(), ec);
 }
 
 bool listDirectory(const String& path, bool filesOnly, HashSet<String> dirList) {
-    try {
-        for (boost::filesystem::directory_iterator dir(path.c_str()); dir != boost::filesystem::directory_iterator(); ++dir) {
-            if (!filesOnly || !boost::filesystem::is_directory(dir->status())) {
-                dirList.add(dir->path().filename().wstring().c_str());
-            }
-        }
-        return true;
-    } catch (...) {
+    boost::system::error_code ec;
+    boost::filesystem::directory_iterator dir(path.c_str(), ec);
+    if (ec) {
         return false;
     }
+
+    for (; dir != boost::filesystem::directory_iterator(); ++dir) {
+        if (!filesOnly || !boost::filesystem::is_directory(dir->status())) {
+            dirList.add(dir->path().filename().wstring().c_str());
+        }
+    }
+    return true;
 }
 
 bool copyDirectory(const String& source, const String& dest) {
-    try {
-        HashSet<String> dirList(HashSet<String>::newInstance());
-        if (!listDirectory(source, true, dirList)) {
-            return false;
-        }
-
-        createDirectory(dest);
-
-        for (HashSet<String>::iterator file = dirList.begin(); file != dirList.end(); ++file) {
-            copyFile(joinPath(source, *file), joinPath(dest, *file));
-        }
-
-        return true;
-    } catch (...) {
+    HashSet<String> dirList(HashSet<String>::newInstance());
+    if (!listDirectory(source, true, dirList)) {
         return false;
     }
+
+    createDirectory(dest);
+
+    for (HashSet<String>::iterator file = dirList.begin(); file != dirList.end(); ++file) {
+        copyFile(joinPath(source, *file), joinPath(dest, *file));
+    }
+
+    return true;
 }
 
 String joinPath(const String& path, const String& file) {
-    try {
-        boost::filesystem::path join(path.c_str());
-        join /= file.c_str();
-        return join.wstring().c_str();
-    } catch (...) {
-        return path;
-    }
+    boost::filesystem::path join(path.c_str());
+    join /= file.c_str();
+    return join.wstring().c_str();
 }
 
 String extractPath(const String& path) {
-    try {
-        boost::filesystem::wpath parentPath(path.c_str());
-        return parentPath.parent_path().wstring().c_str();
-    } catch (...) {
-        return path;
-    }
+    boost::filesystem::wpath parentPath(path.c_str());
+    return parentPath.parent_path().wstring().c_str();
 }
 
 String extractFile(const String& path) {
-    try {
-        boost::filesystem::wpath fileName(path.c_str());
-        return fileName.filename().wstring().c_str();
-    } catch (...) {
-        return path;
-    }
+    boost::filesystem::wpath fileName(path.c_str());
+    return fileName.filename().wstring().c_str();
 }
 
 }


### PR DESCRIPTION
It doesn't make much sense to throw exceptions from `boost::filesystem` functions only to
immediately ignore them when we can call them with `boost::system::error_code` argument
to prevent the exceptions from being thrown in the first place.

Notice that while I'm not sure if ignoring all these exceptions is necessarily the right thing to
do it in the first place, I tried to avoid any changes in the code behaviour in this patch, so
I didn't do anything about this.