### PR TITLE
Improves support for building using the CMake MSVC generator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,9 @@ endif()
 if(MSVC)
   # Disable automatic boost linking on Windows as libraries are added to the linker explicitly
   add_definitions(-DBOOST_ALL_NO_LIB)
+
+  # enable exceptions, see http://msdn.microsoft.com/en-us/library/1deeycx5.aspx
+  add_definitions(-EHsc)
 endif()
 
 if(NOT WIN32 AND NOT CMAKE_SYSTEM MATCHES "SunOS-5*.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,12 @@ option(ENABLE_DEMO
 ####################################
 
 find_package(Threads REQUIRED)
+
+if(MSVC)
+    # Disable automatic boost linking on Windows as libraries are added to the linker explicitly
+    add_definitions("/DBOOST_ALL_NO_LIB")
+endif()
+
 find_package(Boost COMPONENTS
   date_time
   filesystem

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,12 +58,6 @@ option(ENABLE_DEMO
 ####################################
 
 find_package(Threads REQUIRED)
-
-if(MSVC)
-    # Disable automatic boost linking on Windows as libraries are added to the linker explicitly
-    add_definitions("/DBOOST_ALL_NO_LIB")
-endif()
-
 find_package(Boost COMPONENTS
   date_time
   filesystem
@@ -105,6 +99,11 @@ endif()
 ####################################
 if(WIN32 OR WIN64)
   set(CMAKE_DEBUG_POSTFIX "d")
+endif()
+
+if(MSVC)
+  # Disable automatic boost linking on Windows as libraries are added to the linker explicitly
+  add_definitions(-DBOOST_ALL_NO_LIB)
 endif()
 
 if(NOT WIN32 AND NOT CMAKE_SYSTEM MATCHES "SunOS-5*.")


### PR DESCRIPTION
The Lucene++ CMake scripts explicitly link in the found boost libraries, so this feature of boost isn't required -- and will cause problems if the boost headers don't know where the libraries are.

See http://www.boost.org/doc/libs/1_56_0/boost/config/user.hpp for official boost docs around this config setting.

Exceptions are enabled in the committed VS projects, but not when generating them via CMake. This causes compilation issues with Boost.Exception as BOOST_NO_EXCEPTION is defined (since the compiler doesn't support exceptions).