### PR TITLE
Enables C++ exceptions when generating VS projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,11 @@ if(WIN32 OR WIN64)
   set(CMAKE_DEBUG_POSTFIX "d")
 endif()
 
+if(MSVC)
+  # enable exceptions, see http://msdn.microsoft.com/en-us/library/1deeycx5.aspx
+  add_definitions(-EHsc)
+endif()
+
 if(NOT WIN32 AND NOT CMAKE_SYSTEM MATCHES "SunOS-5*.")
   add_definitions(-fPIC)
 endif()


### PR DESCRIPTION
Exceptions are enabled in the commited VS projects, but not when generating them via CMake. This causes compilation issues with Boost.Exception as BOOST_NO_EXCEPTION is defined (since the compiler doesn't support exceptions).