### PR TITLE
Use maxSize of BooleanQuery as base for the queue size

### DIFF
--- a/src/core/search/FuzzyQuery.cpp
+++ b/src/core/search/FuzzyQuery.cpp
@@ -83,7 +83,7 @@ QueryPtr FuzzyQuery::rewrite(const IndexReaderPtr& reader) {
     }
 
     int32_t maxSize = BooleanQuery::getMaxClauseCount();
-    ScoreTermQueuePtr stQueue(newLucene<ScoreTermQueue>(1024));
+    ScoreTermQueuePtr stQueue(newLucene<ScoreTermQueue>(maxSize + 1));
     FilteredTermEnumPtr enumerator(getEnum(reader));
     LuceneException finally;
     try {


### PR DESCRIPTION
Use the `MaxClauseCount` from the `BooleanQuery` to limit the ScoreTermQueue. Otherwise we will get an `IndexOutOfBoundsException` in line 104 when we add the 1024th element. Note that we need `maxSize + 1` as we first add a new element and then remove an exceeding element again. Thus we will have at maximum `maxSize` elements at the end of each iteration.