### PR TITLE
Fix packageconfig path.

### DIFF
--- a/liblucene++-contrib.pc.cmake
+++ b/liblucene++-contrib.pc.cmake
@@ -1,13 +1,13 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}/bin
-libdir=${prefix}/@LIB_DESTINATION@
+libdir=@LIB_DESTINATION@
 includedir=${prefix}/include/lucene++
 lib=lucene++-contrib
 
 Name: liblucene++-contrib
 Description: Contributions for Lucene++ - a C++ search engine, ported from the popular Apache Lucene
 Version: @lucene++_VERSION@
-Libs: -L${prefix}/@LIB_DESTINATION@ -l${lib}
+Libs: -L@LIB_DESTINATION@ -l${lib}
 Cflags: -I${includedir}
 Requires: liblucene++ = @lucene++_VERSION@
 

--- a/liblucene++.pc.cmake
+++ b/liblucene++.pc.cmake
@@ -1,12 +1,12 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}/bin
-libdir=${prefix}/@LIB_DESTINATION@
+libdir=@LIB_DESTINATION@
 includedir=${prefix}/include/lucene++
 lib=lucene++
 
 Name: liblucene++
 Description: Lucene++ - a C++ search engine, ported from the popular Apache Lucene
 Version: @lucene++_VERSION@
-Libs: -L${prefix}/@LIB_DESTINATION@ -l${lib}
+Libs: -L@LIB_DESTINATION@ -l${lib}
 Cflags: -I${includedir}
 


### PR DESCRIPTION
Rationale: LIB_DESTINATION is set as CMAKE_INSTALL_FULL_LIBDIR. So repeating "{prefix}"
results in a double usr/usr inclusion