### PR TITLE
Link against `libboost_system` when building demo

### DIFF
--- a/src/demo/CMakeLists.txt
+++ b/src/demo/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.0)
 project(lucene++-demo)
 
 file(GLOB_RECURSE
@@ -6,6 +7,7 @@ file(GLOB_RECURSE
 )
 
 add_definitions(-DLPP_HAVE_DLL)
+find_package(Boost REQUIRED)
 
 include_directories(
   ${Boost_INCLUDE_DIRS}
@@ -19,7 +21,7 @@ add_executable(indexfiles
   ${demo_headers}
 )
 target_link_libraries(indexfiles
-  lucene++
+  lucene++ boost_system
 )
 
 add_executable(searchfiles
@@ -27,7 +29,7 @@ add_executable(searchfiles
   ${demo_headers}
 )
 target_link_libraries(searchfiles
-  lucene++
+  lucene++ boost_system
 )
 
 add_executable(deletefiles
@@ -35,5 +37,5 @@ add_executable(deletefiles
   ${demo_headers}
 )
 target_link_libraries(deletefiles
-  lucene++
+  lucene++ boost_system
 )


### PR DESCRIPTION
* Added `cmake_minimum_required()` statement at the top of CMakeLists.txt
    * (as per verbose development output from `cmake`)
* Added call to `find_package()` to find Boost
* Specified `boost_system` in all calls to `target_link_libraries()`

… These allow the codebase (as of `HEAD`) to build for me – on OS X 10.10, with Apple Clang 6.1, CMake 3.3, Boost 1.58 (built with C++11 flags. Yes!