### PR TITLE
Work around clang warning about side effects inside typeid()

### DIFF
--- a/src/core/util/MiscUtils.cpp
+++ b/src/core/util/MiscUtils.cpp
@@ -119,7 +119,9 @@ bool MiscUtils::isNaN(double value) {
 }
 
 bool MiscUtils::equalTypes(const LuceneObjectPtr& first, const LuceneObjectPtr& second) {
-    return (typeid(*first) == typeid(*second));
+    const LuceneObject& firstRef(*first);
+    const LuceneObject& secondRef(*second);
+    return (typeid(firstRef) == typeid(secondRef));
 }
 
 int64_t MiscUtils::unsignedShift(int64_t num, int64_t shift) {


### PR DESCRIPTION
This warning is harmless here, but warnings-free build is even more harmless.

Clang's warning looks like this:

> LucenePlusPlus/src/core/util/MiscUtils.cpp:122:38: Expression with side effects will be evaluated despite being used as an operand to 'typeid'

A very detailed discussion of the same warning in another problem is at http://trac.wxwidgets.org/ticket/16968 and this PR's approach (including the use of references instead of pointers) is inspired by it.