### PR TITLE
Define NOMINMAX globally on Windows to avoid windows.h macro clashes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,8 @@ endif()
 ####################################
 if(WIN32 OR WIN64)
   set(CMAKE_DEBUG_POSTFIX "d")
+  # Don't define MIN() or MAX() macros as these clash with std::min and std::max
+  add_definitions(-DNOMINMAX)
 endif()
 
 if(MSVC)


### PR DESCRIPTION
The current master doesn't build under windows with:

 ```
mkdir build
pushd build
cmake .. -G "Visual Studio 10 2010"
popd
cmake --build build --config Debug
```

It fails with quite a few of:
```
8>..\..\..\src\contrib\highlighter\TokenGroup.cpp(54): error C2589: '(' : illegal token on right side of '::'
8>..\..\..\src\contrib\highlighter\TokenGroup.cpp(54): error C2059: syntax error : '::'
```

There's a few clashes, mostly localized to `src/contrib`

Note that I haven't touched the existing `#define NOMINMAX` lines which are in some of the `...Inc.h` headers.