### PR TITLE
Handle all non-BMP chars as letters

### DIFF
--- a/src/core/analysis/standard/StandardTokenizerImpl.cpp
+++ b/src/core/analysis/standard/StandardTokenizerImpl.cpp
@@ -425,11 +425,13 @@ int32_t StandardTokenizerImpl::getNextToken() {
     // Multilingual Plane. As a workaround to prevent crashes, treat all
     // characters above U+FFFF as letters in the tokenizer.
     // See https://github.com/luceneplusplus/LucenePlusPlus/issues/57
-#ifdef LPP_UNICODE_CHAR_SIZE_4
     const wchar_t zzCMapFallback = zzCMapL['A'];
+#ifdef LPP_UNICODE_CHAR_SIZE_4
     #define zzCMap_at(n) ((n) > 0xFFFF ? zzCMapFallback : zzCMapL[n])
 #else
-    #define zzCMap_at(n) (zzCMapL[n])
+    // If the 16-bit value is in [0xD800, 0xDFFF], it is part of a multi-byte 
+    // UTF-16 character and its UTF code point is > U+FFFF, so handle as above.
+    #define zzCMap_at(n) (((n) & 0xF800) == 0xD800 ? zzCMapFallback : zzCMapL[n])
 #endif
 
     const int32_t* zzTransL = ZZ_TRANS();


### PR DESCRIPTION
`StandardTokenizerImpl` cannot handle unicode characters outside the Basic Multilingual Plane (code point > U+FFFF).  

A workaround was introduced previously to treat all such characters as alphanumeric when the native wide character format is UTF-32: https://github.com/luceneplusplus/LucenePlusPlus/commit/74ef19235a2359497c043d200cc4826fa1a46a35

However, after that change, the same unicode character was treated differently by `StandardTokenizerImpl` depending on whether the native wide character encoding is UTF-32 or not, and therefore it would generate different results on Windows and unix platforms.  

This change handles unicode values > U+FFFF encoded in UTF-16 in the same way that the above change handles them for UTF-32, allowing for consistent behavior across all platforms.