### PR TITLE
fix improper override

### DIFF
--- a/include/PhraseScorer.h
+++ b/include/PhraseScorer.h
@@ -46,7 +46,7 @@ public:
 
     /// Phrase frequency in current doc as computed by phraseFreq().
     double currentFreq();
-    float termFreq(){
+    virtual float termFreq(){
         return currentFreq();
     }
     


### PR DESCRIPTION
This method was masking virtual function `float Scorer::termFreq()`