### PR TITLE
fix stem filter

### DIFF
--- a/src/core/analysis/PorterStemFilter.cpp
+++ b/src/core/analysis/PorterStemFilter.cpp
@@ -24,7 +24,7 @@ bool PorterStemFilter::incrementToken() {
         return false;
     }
 
-    if (stemmer->stem(termAtt->termBuffer())) {
+    if (stemmer->stem(termAtt->termBufferArray(), termAtt->termLength() - 1)) {
         termAtt->setTermBuffer(stemmer->getResultBuffer(), 0, stemmer->getResultLength());
     }
     return true;


### PR DESCRIPTION
`termAtt->termBuffer()->size()` is not equivalent to `termAtt->termLength()` in all cases which would cause this call to `stemmer->stem()` to produce invalid results.  
See also `PorterStemmer::stem(CharArray word)`: 
https://github.com/luceneplusplus/LucenePlusPlus/blob/b7baba57d9bab88dde4e9569ffa14885d8b575eb/src/core/analysis/PorterStemmer.cpp#L23-L25

Other potentially problematic uses of `TermAttribute::termBuffer()` are in `KeywordTokenizer` and `CharTokenizer` below, but I'm not familiar enough with the implementation of these systems to make changes at this time:
https://github.com/luceneplusplus/LucenePlusPlus/blob/b7baba57d9bab88dde4e9569ffa14885d8b575eb/src/core/analysis/KeywordTokenizer.cpp#L49
https://github.com/luceneplusplus/LucenePlusPlus/blob/b7baba57d9bab88dde4e9569ffa14885d8b575eb/src/core/analysis/CharTokenizer.cpp#L59