### PR TITLE
Assign lockFile value in SimpleFSLock constructor

### DIFF
--- a/src/core/store/SimpleFSLockFactory.cpp
+++ b/src/core/store/SimpleFSLockFactory.cpp
@@ -38,7 +38,7 @@ void SimpleFSLockFactory::clearLock(const String& lockName) {
 
 SimpleFSLock::SimpleFSLock(const String& lockDir, const String& lockFileName) {
     this->lockDir = lockDir;
-    this->lockFile = lockFile;
+    this->lockFile = lockFileName;
 }
 
 SimpleFSLock::~SimpleFSLock() {


### PR DESCRIPTION
Due to a typo, the `lockFile` member was always empty -- the constructor assigned it to itself.

Credit goes to Xcode 10.2's default warnings for uncovering this.