### PR TITLE
fix broken override KeywordTokenizer::reset()

### DIFF
--- a/include/KeywordTokenizer.h
+++ b/include/KeywordTokenizer.h
@@ -37,7 +37,7 @@ protected:
 public:
     virtual bool incrementToken();
     virtual void end();
-    virtual void reset();
+    virtual void reset(const ReaderPtr &input);
 };
 
 }

--- a/src/core/analysis/KeywordTokenizer.cpp
+++ b/src/core/analysis/KeywordTokenizer.cpp
@@ -70,7 +70,7 @@ void KeywordTokenizer::end() {
     offsetAtt->setOffset(finalOffset, finalOffset);
 }
 
-void KeywordTokenizer::reset() {
+void KeywordTokenizer::reset(const ReaderPtr &input) {
     Tokenizer::reset(input);
     done = false;
 }


### PR DESCRIPTION
This is supposed to override `Tokenizer::reset( const ReaderPtr& input )`: https://github.com/luceneplusplus/LucenePlusPlus/blob/3bc5c686fa403a0f71a1aec391d55f3be1b967a8/include/Tokenizer.h#L65