### PR TITLE
Propagate errors reading input files

### DIFF
--- a/include/LuceneException.h
+++ b/include/LuceneException.h
@@ -52,11 +52,15 @@ protected:
     ExceptionType type;
     String error;
 
+    std::string _what;
+
 public:
     ExceptionType getType() const;
     String getError() const;
     bool isNull() const;
     void throwException();
+
+    virtual const char* what() const throw();
 };
 
 template <class ParentException, LuceneException::ExceptionType Type>

--- a/src/core/store/SimpleFSDirectory.cpp
+++ b/src/core/store/SimpleFSDirectory.cpp
@@ -122,6 +122,11 @@ void SimpleFSIndexInput::readInternal(uint8_t* b, int32_t offset, int32_t length
         if (i == InputFile::FILE_EOF) {
             boost::throw_exception(IOException(L"Read past EOF"));
         }
+        else if (i == InputFile::FILE_ERROR) {
+            std::wostringstream msg;
+            msg << L"Failed to read from file: " << path;
+            boost::throw_exception(IOException(msg.str()));
+        }
         total += i;
     }
 }

--- a/src/core/util/LuceneException.cpp
+++ b/src/core/util/LuceneException.cpp
@@ -6,12 +6,16 @@
 
 #include "LuceneInc.h"
 #include "LuceneException.h"
+#include "StringUtils.h"
 
 namespace Lucene {
 
 LuceneException::LuceneException(const String& error, ExceptionType type) throw() {
     this->error = error;
     this->type = type;
+    SingleStringStream ss;
+    ss << "LuceneException[" << type << "]: " << StringUtils::toUTF8(error);
+    this->_what = ss.str();
 }
 
 LuceneException::~LuceneException() throw() {
@@ -89,6 +93,11 @@ void LuceneException::throwException() {
         // silence static analyzer
         break;
     }
+}
+
+const char* LuceneException::what() const throw()
+{
+    return _what.c_str();
 }
 
 }


### PR DESCRIPTION
This fixes an issue where `SimpleFSIndexInput::readInternal()` could get into an infinite loop if it encountered a read error.
Also add a proper `what()` to `LuceneException`.