### PR TITLE
Use CMAKE_CURRENT_SOURCE_DIR for CMAKE_MODULE_PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set(lucene++_VERSION
 )
 
 # include specific modules
-set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 ####################################
 # pre-compiled headers support


### PR DESCRIPTION
The top-level `CMakeLists.txt` is setting `CMAKE_MODULE_PATH` based on `CMAKE_SOURCE_DIR`. This causes failure to find the CMake modules when Lucene++ is included as a submodule in another project.

This commit fixes the definition of `CMAKE_MODULE_PATH` by using `CMAKE_CURRENT_SOURCE_DIR` instead.

Note that everywhere else in `CMakeLists.txt`, the correct variable (`CMAKE_CURRENT_SOURCE_DIR`) is used already.