### PR TITLE
Add LUCENE_BUILD_STATIC option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,10 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")
 endif()
 
+option(LUCENE_BUILD_STATIC
+  "Build a static library"
+  OFF
+)
 option(ENABLE_PACKAGING
   "Create build scripts for creating lucene++ packages"
   OFF

--- a/src/contrib/CMakeLists.txt
+++ b/src/contrib/CMakeLists.txt
@@ -34,10 +34,17 @@ install(FILES ${contrib_headers}
   COMPONENT development-contrib
 )
 
-add_library(lucene++-contrib SHARED
-  ${contrib_sources}
-  ${contrib_headers}
-)
+if (LUCENE_BUILD_STATIC)
+  add_library(lucene++-contrib STATIC
+    ${contrib_sources}
+    ${contrib_headers}
+  )
+else()
+  add_library(lucene++-contrib SHARED
+    ${contrib_sources}
+    ${contrib_headers}
+  )
+endif()
 
 set_target_properties(lucene++-contrib PROPERTIES
   VERSION ${lucene++_VERSION}

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -25,9 +25,15 @@ file(GLOB_RECURSE lucene_headers
 
 add_definitions(-DLPP_BUILDING_LIB)
 
-add_library(lucene++ SHARED
-  ${lucene_sources}
-)
+if (LUCENE_BUILD_STATIC)
+  add_library(lucene++ STATIC
+    ${lucene_sources}
+  )
+else()
+  add_library(lucene++ SHARED
+    ${lucene_sources}
+  )
+endif()
 
 target_link_libraries(lucene++
   ${CMAKE_THREAD_LIBS_INIT}


### PR DESCRIPTION
Hi,

This PR adds a LUCENE_BUILD_STATIC CMake option to produce a static library.

- Currently, the CMake build only produces a shared library and we have to modify the source to get a static one.
- With this change, a static lib can be obtained via a parent CMake project without modifying Lucene++'s source. This is especially convenient when Lucene is a submodule of the project it depends on as the parent project is able to customize the build of its dependencies in its own CMake config.

Other projects that provide such an option:
- [TBB](https://github.com/wjakob/tbb/blob/20357d83871e4cb93b2c724fe0c337cd999fd14f/CMakeLists.txt#L44)
- [OpenVDB](https://github.com/AcademySoftwareFoundation/openvdb/blob/eba1a2e8ad1cf3813acbee866fa69cbfcabc0295/openvdb/CMakeLists.txt#L21)