### PR TITLE
Define WIN32_LEAN_AND_MEAN and NOMINMAX via CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,12 @@ if(MSVC)
 
   # enable exceptions, see http://msdn.microsoft.com/en-us/library/1deeycx5.aspx
   add_definitions(-EHsc)
+
+  # Disable including too many Windows headers
+  add_definitions(-DWIN32_LEAN_AND_MEAN)
+
+  # Disable the min/max macros that conflict with std::min/std::max
+  add_definitions(-DNOMINMAX)
 endif()
 
 if(NOT WIN32 AND NOT CMAKE_SYSTEM MATCHES "SunOS-5*.")

--- a/src/contrib/include/ContribInc.h
+++ b/src/contrib/include/ContribInc.h
@@ -8,8 +8,13 @@
 
 #include "targetver.h"
 
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
+
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 
 #include <windows.h>
 

--- a/src/core/include/LuceneInc.h
+++ b/src/core/include/LuceneInc.h
@@ -8,7 +8,10 @@
 
 #include "targetver.h"
 
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
+
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif

--- a/src/demo/deletefiles/main.cpp
+++ b/src/demo/deletefiles/main.cpp
@@ -4,7 +4,9 @@
 // or the GNU Lesser General Public License.
 /////////////////////////////////////////////////////////////////////////////
 
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 
 #include "targetver.h"
 #include <iostream>

--- a/src/demo/indexfiles/main.cpp
+++ b/src/demo/indexfiles/main.cpp
@@ -4,7 +4,9 @@
 // or the GNU Lesser General Public License.
 /////////////////////////////////////////////////////////////////////////////
 
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 
 #include "targetver.h"
 #include <iostream>

--- a/src/demo/searchfiles/main.cpp
+++ b/src/demo/searchfiles/main.cpp
@@ -4,7 +4,13 @@
 // or the GNU Lesser General Public License.
 /////////////////////////////////////////////////////////////////////////////
 
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 
 #include "targetver.h"
 #include <iostream>

--- a/src/test/include/TestInc.h
+++ b/src/test/include/TestInc.h
@@ -8,8 +8,13 @@
 
 #include "targetver.h"
 
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
+
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 
 #include <windows.h>
 

--- a/src/test/main/main.cpp
+++ b/src/test/main/main.cpp
@@ -10,8 +10,13 @@
 
 #include "targetver.h"
 
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
+
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 
 #include <windows.h>
 


### PR DESCRIPTION
Hi,

I am unable to build Lucene++ out of the box on Windows, with Visual Studio 2017.
The build fails due to **conflicts between the STL's min/max functions and those provided by Windows headers**.

Even though the NOMINMAX macro is defined in Lucene++'s source code (`LuceneInc.h` + `ContribInc.h` ...), it seems that it's defined too late (I was not able to find where the conflict is coming from though).

**This PR defines the NOMINMAX macro (as well as WIN32_LEAN_AND_MEAN) at the project level, so that we do not have to rely on the inclusion order of source files.**

I also added define guards in the source files that redefine those to prevent Visual Studio warnings about multiple redefinitions.