### PR TITLE
added BOOST_USE_WINDOWS_H to config.h

### DIFF
--- a/include/Config.h.cmake
+++ b/include/Config.h.cmake
@@ -81,3 +81,8 @@
 #define BOOST_FILESYSTEM_VERSION 3
 
 #endif
+
+// Use windows definitions
+#if defined(_WIN32) || defined(_WIN64)
+#define BOOST_USE_WINDOWS_H
+#endif


### PR DESCRIPTION
fixes compilation on windows. Without definition, conflicting definitions in msvc
and boost cause errors.