### PR TITLE
added LPPAPI definitions missing in headers

### DIFF
--- a/include/Base64.h
+++ b/include/Base64.h
@@ -11,7 +11,7 @@
 
 namespace Lucene {
 
-class Base64 : public LuceneObject {
+class LPPAPI Base64 : public LuceneObject {
 public:
     virtual ~Base64();
     LUCENE_CLASS(Base64);

--- a/include/InputStreamReader.h
+++ b/include/InputStreamReader.h
@@ -12,7 +12,7 @@
 namespace Lucene {
 
 /// An InputStreamReader is a bridge from byte streams to character streams.
-class InputStreamReader : public Reader {
+class LPPAPI InputStreamReader : public Reader {
 public:
     /// Create an InputStreamReader that uses the utf8 charset.
     InputStreamReader(const ReaderPtr& reader);

--- a/include/TestPoint.h
+++ b/include/TestPoint.h
@@ -12,7 +12,7 @@
 namespace Lucene {
 
 /// Used for unit testing as a substitute for stack trace
-class TestPoint {
+class LPPAPI TestPoint {
 public:
     virtual ~TestPoint();
 

--- a/include/UTF8Stream.h
+++ b/include/UTF8Stream.h
@@ -11,7 +11,7 @@
 
 namespace Lucene {
 
-class UTF8Base : public LuceneObject {
+class LPPAPI UTF8Base : public LuceneObject {
 public:
     virtual ~UTF8Base();
     LUCENE_CLASS(UTF8Base);


### PR DESCRIPTION
adds a couple missing LPPAPI flags needed for building LucenePlusPlus
with hidden symbols (-fvisibility='hidden'). may be more missing ones, but
without these the linking of the test bin to the core library fails. 

ran tests to double check, all tests passed.