### PR TITLE
added missing WIN32_LEAN_AND_MEAN definition to demos

### DIFF
--- a/src/demo/deletefiles/main.cpp
+++ b/src/demo/deletefiles/main.cpp
@@ -4,6 +4,10 @@
 // or the GNU Lesser General Public License.
 /////////////////////////////////////////////////////////////////////////////
 
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif

--- a/src/demo/indexfiles/main.cpp
+++ b/src/demo/indexfiles/main.cpp
@@ -4,6 +4,10 @@
 // or the GNU Lesser General Public License.
 /////////////////////////////////////////////////////////////////////////////
 
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif


### PR DESCRIPTION
demo executables were missing WIN32_LEAN_AND_MEAN definitions,
caused issues compiling on windows; this PR fixes this.