### PR TITLE
fixed missing LPPAPI definitions

### DIFF
--- a/include/BooleanScorer.h
+++ b/include/BooleanScorer.h
@@ -27,7 +27,7 @@ namespace Lucene {
 /// the last, then there's a hit.  When some terms are required and some terms are optional, the conjunction can
 /// be evaluated first, then the optional terms can all skip to the match and be added to the score. Thus the
 /// conjunction can reduce the number of priority queue updates for the optional terms.
-class BooleanScorer : public Scorer {
+class LPPAPI BooleanScorer : public Scorer {
 public:
     BooleanScorer(const SimilarityPtr& similarity, int32_t minNrShouldMatch, Collection<ScorerPtr> optionalScorers, Collection<ScorerPtr> prohibitedScorers);
     virtual ~BooleanScorer();

--- a/include/ByteBlockPool.h
+++ b/include/ByteBlockPool.h
@@ -20,7 +20,7 @@ namespace Lucene {
 /// Each slice is filled with 0's initially, and we mark the end with a non-zero byte.  This way the methods
 /// that are writing into the slice don't need to record its length and instead allocate a new slice once
 /// they hit a non-zero byte.
-class ByteBlockPool : public LuceneObject {
+class LPPAPI ByteBlockPool : public LuceneObject {
 public:
     ByteBlockPool(const ByteBlockPoolAllocatorBasePtr& allocator, bool trackAllocations);
     virtual ~ByteBlockPool();
@@ -51,7 +51,7 @@ public:
     int32_t allocSlice(ByteArray slice, int32_t upto);
 };
 
-class ByteBlockPoolAllocatorBase : public LuceneObject {
+class LPPAPI ByteBlockPoolAllocatorBase : public LuceneObject {
 public:
     virtual ~ByteBlockPoolAllocatorBase();
 

--- a/include/ByteSliceReader.h
+++ b/include/ByteSliceReader.h
@@ -13,7 +13,7 @@ namespace Lucene {
 
 /// IndexInput that knows how to read the byte slices written by Posting and PostingVector.  We read the bytes in each slice
 /// until we hit the end of that slice at which point we read the forwarding address of the next slice and then jump to it.
-class ByteSliceReader : public IndexInput {
+class LPPAPI ByteSliceReader : public IndexInput {
 public:
     ByteSliceReader();
     virtual ~ByteSliceReader();

--- a/include/ByteSliceWriter.h
+++ b/include/ByteSliceWriter.h
@@ -13,7 +13,7 @@ namespace Lucene {
 
 /// Class to write byte streams into slices of shared byte[].  This is used by DocumentsWriter to hold
 /// the posting list for many terms in RAM.
-class ByteSliceWriter : public LuceneObject {
+class LPPAPI ByteSliceWriter : public LuceneObject {
 public:
     ByteSliceWriter(const ByteBlockPoolPtr& pool);
     virtual ~ByteSliceWriter();

--- a/include/CompoundFileReader.h
+++ b/include/CompoundFileReader.h
@@ -15,7 +15,7 @@ namespace Lucene {
 /// Class for accessing a compound stream.
 /// This class implements a directory, but is limited to only read operations.
 /// Directory methods that would normally modify data throw an exception.
-class CompoundFileReader : public Directory {
+class LPPAPI CompoundFileReader : public Directory {
 public:
     CompoundFileReader(const DirectoryPtr& dir, const String& name);
     CompoundFileReader(const DirectoryPtr& dir, const String& name, int32_t readBufferSize);
@@ -80,7 +80,7 @@ public:
 };
 
 /// Implementation of an IndexInput that reads from a portion of the compound file.
-class CSIndexInput : public BufferedIndexInput {
+class LPPAPI CSIndexInput : public BufferedIndexInput {
 public:
     CSIndexInput();
     CSIndexInput(const IndexInputPtr& base, int64_t fileOffset, int64_t length);

--- a/include/CompoundFileWriter.h
+++ b/include/CompoundFileWriter.h
@@ -24,7 +24,7 @@ namespace Lucene {
 /// The fileCount integer indicates how many files are contained in this compound file. The {directory}
 /// that follows has that many entries. Each directory entry contains a long pointer to the start of
 /// this file's data section, and a string with that file's name.
-class CompoundFileWriter : public LuceneObject {
+class LPPAPI CompoundFileWriter : public LuceneObject {
 public:
     CompoundFileWriter(const DirectoryPtr& dir, const String& name, const CheckAbortPtr& checkAbort = CheckAbortPtr());
     virtual ~CompoundFileWriter();

--- a/include/DirectoryReader.h
+++ b/include/DirectoryReader.h
@@ -16,7 +16,7 @@
 namespace Lucene {
 
 /// An IndexReader which reads indexes with multiple segments.
-class DirectoryReader : public IndexReader {
+class LPPAPI DirectoryReader : public IndexReader {
 public:
     /// Construct reading the named set of readers.
     DirectoryReader(const DirectoryPtr& directory, const SegmentInfosPtr& sis, const IndexDeletionPolicyPtr& deletionPolicy, bool readOnly, int32_t termInfosIndexDivisor);

--- a/include/DocumentsWriter.h
+++ b/include/DocumentsWriter.h
@@ -51,7 +51,7 @@ namespace Lucene {
 /// updates are consistent, but, they represent only a part of the document seen up until the exception was hit.
 /// When this happens, we immediately mark the document as deleted so that the document is always atomically
 /// ("all or none") added to the index.
-class DocumentsWriter : public LuceneObject {
+class LPPAPI DocumentsWriter : public LuceneObject {
 public:
     DocumentsWriter(const DirectoryPtr& directory, const IndexWriterPtr& writer, const IndexingChainPtr& indexingChain);
     virtual ~DocumentsWriter();

--- a/include/FieldInfos.h
+++ b/include/FieldInfos.h
@@ -15,7 +15,7 @@ namespace Lucene {
 /// Each segment has a separate Fieldable Info file. Objects of this class are thread-safe for multiple
 /// readers, but only one thread can be adding documents at a time, with no other reader or writer threads
 /// accessing this object.
-class FieldInfos : public LuceneObject {
+class LPPAPI FieldInfos : public LuceneObject {
 public:
     FieldInfos();
 

--- a/include/FieldsReader.h
+++ b/include/FieldsReader.h
@@ -13,7 +13,7 @@
 namespace Lucene {
 
 /// Class responsible for access to stored document fields.  It uses <segment>.fdt and <segment>.fdx; files.
-class FieldsReader : public LuceneObject {
+class LPPAPI FieldsReader : public LuceneObject {
 public:
     /// Used only by clone
     FieldsReader(const FieldInfosPtr& fieldInfos, int32_t numTotalDocs, int32_t size, int32_t format, int32_t formatSize,

--- a/include/HitQueue.h
+++ b/include/HitQueue.h
@@ -11,7 +11,7 @@
 
 namespace Lucene {
 
-class HitQueue : public HitQueueBase {
+class LPPAPI HitQueue : public HitQueueBase {
 public:
     /// Creates a new instance with size elements.
     HitQueue(int32_t size, bool prePopulate);

--- a/include/IndexFileDeleter.h
+++ b/include/IndexFileDeleter.h
@@ -31,7 +31,7 @@ namespace Lucene {
 ///
 /// Note that you must hold the write.lock before instantiating this class.  It opens segments_N file(s) directly
 /// with no retry logic.
-class IndexFileDeleter : public LuceneObject {
+class LPPAPI IndexFileDeleter : public LuceneObject {
 public:
     /// Initialize the deleter: find all previous commits in the Directory, incref the files they reference, call
     /// the policy to let it delete commits.  This will remove any files not referenced by any of the commits.

--- a/include/IndexFileNames.h
+++ b/include/IndexFileNames.h
@@ -12,7 +12,7 @@
 namespace Lucene {
 
 /// Constants representing filenames and extensions used by Lucene.
-class IndexFileNames : public LuceneObject {
+class LPPAPI IndexFileNames : public LuceneObject {
 public:
     virtual ~IndexFileNames();
     LUCENE_CLASS(IndexFileNames);

--- a/include/RAMInputStream.h
+++ b/include/RAMInputStream.h
@@ -12,7 +12,7 @@
 namespace Lucene {
 
 /// A memory-resident {@link IndexInput} implementation.
-class RAMInputStream : public IndexInput {
+class LPPAPI RAMInputStream : public IndexInput {
 public:
     RAMInputStream();
     RAMInputStream(const RAMFilePtr& f);

--- a/include/RAMOutputStream.h
+++ b/include/RAMOutputStream.h
@@ -12,7 +12,7 @@
 namespace Lucene {
 
 /// A memory-resident {@link IndexOutput} implementation.
-class RAMOutputStream : public IndexOutput {
+class LPPAPI RAMOutputStream : public IndexOutput {
 public:
     /// Construct an empty output buffer.
     RAMOutputStream();

--- a/include/ReadOnlyDirectoryReader.h
+++ b/include/ReadOnlyDirectoryReader.h
@@ -11,7 +11,7 @@
 
 namespace Lucene {
 
-class ReadOnlyDirectoryReader : public DirectoryReader {
+class LPPAPI ReadOnlyDirectoryReader : public DirectoryReader {
 public:
     ReadOnlyDirectoryReader(const DirectoryPtr& directory, const SegmentInfosPtr& sis, const IndexDeletionPolicyPtr& deletionPolicy, int32_t termInfosIndexDivisor);
     ReadOnlyDirectoryReader(const DirectoryPtr& directory, const SegmentInfosPtr& infos, Collection<SegmentReaderPtr> oldReaders,

--- a/include/ReadOnlySegmentReader.h
+++ b/include/ReadOnlySegmentReader.h
@@ -11,7 +11,7 @@
 
 namespace Lucene {
 
-class ReadOnlySegmentReader : public SegmentReader {
+class LPPAPI ReadOnlySegmentReader : public SegmentReader {
 public:
     virtual ~ReadOnlySegmentReader();
 

--- a/include/SegmentMerger.h
+++ b/include/SegmentMerger.h
@@ -17,7 +17,7 @@ namespace Lucene {
 /// If the compoundFile flag is set, then the segments will be merged into a compound file.
 /// @see #merge
 /// @see #add
-class SegmentMerger : public LuceneObject {
+class LPPAPI SegmentMerger : public LuceneObject {
 public:
     SegmentMerger(const DirectoryPtr& dir, const String& name);
     SegmentMerger(const IndexWriterPtr& writer, const String& name, const OneMergePtr& merge);

--- a/include/SegmentTermDocs.h
+++ b/include/SegmentTermDocs.h
@@ -11,7 +11,7 @@
 
 namespace Lucene {
 
-class SegmentTermDocs : public TermPositions, public LuceneObject {
+class LPPAPI SegmentTermDocs : public TermPositions, public LuceneObject {
 public:
     SegmentTermDocs(const SegmentReaderPtr& parent);
     virtual ~SegmentTermDocs();

--- a/include/SegmentTermEnum.h
+++ b/include/SegmentTermEnum.h
@@ -11,7 +11,7 @@
 
 namespace Lucene {
 
-class SegmentTermEnum : public TermEnum {
+class LPPAPI SegmentTermEnum : public TermEnum {
 public:
     SegmentTermEnum();
     SegmentTermEnum(const IndexInputPtr& i, const FieldInfosPtr& fis, bool isi);

--- a/include/SegmentTermPositionVector.h
+++ b/include/SegmentTermPositionVector.h
@@ -11,7 +11,7 @@
 
 namespace Lucene {
 
-class SegmentTermPositionVector : public SegmentTermVector {
+class LPPAPI SegmentTermPositionVector : public SegmentTermVector {
 public:
     SegmentTermPositionVector(const String& field, Collection<String> terms, Collection<int32_t> termFreqs,
                               Collection< Collection<int32_t> > positions, Collection< Collection<TermVectorOffsetInfoPtr> > offsets);

--- a/include/SegmentTermPositions.h
+++ b/include/SegmentTermPositions.h
@@ -11,7 +11,7 @@
 
 namespace Lucene {
 
-class SegmentTermPositions : public SegmentTermDocs {
+class LPPAPI SegmentTermPositions : public SegmentTermDocs {
 public:
     SegmentTermPositions(const SegmentReaderPtr& parent);
     virtual ~SegmentTermPositions();

--- a/include/SegmentTermVector.h
+++ b/include/SegmentTermVector.h
@@ -11,7 +11,7 @@
 
 namespace Lucene {
 
-class SegmentTermVector : public TermPositionVector, public LuceneObject {
+class LPPAPI SegmentTermVector : public TermPositionVector, public LuceneObject {
 public:
     SegmentTermVector(const String& field, Collection<String> terms, Collection<int32_t> termFreqs);
     virtual ~SegmentTermVector();

--- a/include/TermScorer.h
+++ b/include/TermScorer.h
@@ -12,7 +12,7 @@
 namespace Lucene {
 
 /// A Scorer for documents matching a Term.
-class TermScorer : public Scorer {
+class LPPAPI TermScorer : public Scorer {
 public:
     /// Construct a TermScorer.
     /// @param weight The weight of the Term in the query.

--- a/include/TermVectorsReader.h
+++ b/include/TermVectorsReader.h
@@ -11,7 +11,7 @@
 
 namespace Lucene {
 
-class TermVectorsReader : public LuceneObject {
+class LPPAPI TermVectorsReader : public LuceneObject {
 public:
     TermVectorsReader();
     TermVectorsReader(const DirectoryPtr& d, const String& segment, const FieldInfosPtr& fieldInfos);

--- a/include/TestPoint.h
+++ b/include/TestPoint.h
@@ -28,7 +28,7 @@ public:
     static bool getTestPoint(const String& method);
 };
 
-class TestScope {
+class LPPAPI TestScope {
 public:
     TestScope(const String& object, const String& method);
     virtual ~TestScope();

--- a/src/core/include/_ConcurrentMergeScheduler.h
+++ b/src/core/include/_ConcurrentMergeScheduler.h
@@ -11,7 +11,7 @@
 
 namespace Lucene {
 
-class MergeThread : public LuceneThread {
+class LPPAPI MergeThread : public LuceneThread {
 public:
     MergeThread(const ConcurrentMergeSchedulerPtr& merger, const IndexWriterPtr& writer, const OneMergePtr& startMerge);
     virtual ~MergeThread();

--- a/src/core/include/_NumericRangeQuery.h
+++ b/src/core/include/_NumericRangeQuery.h
@@ -17,7 +17,7 @@ namespace Lucene {
 /// Warning: This term enumeration is not guaranteed to be always ordered by {@link Term#compareTo}.  The
 /// ordering depends on how {@link NumericUtils#splitLongRange} and {@link NumericUtils#splitIntRange}
 /// generates the sub-ranges.  For {@link MultiTermQuery} ordering is not relevant.
-class NumericRangeTermEnum : public FilteredTermEnum {
+class LPPAPI NumericRangeTermEnum : public FilteredTermEnum {
 public:
     NumericRangeTermEnum(const NumericRangeQueryPtr& query, const IndexReaderPtr& reader);
     virtual ~NumericRangeTermEnum();

--- a/src/core/include/_SegmentReader.h
+++ b/src/core/include/_SegmentReader.h
@@ -66,7 +66,7 @@ public:
 };
 
 /// Sets the initial value
-class FieldsReaderLocal : public CloseableThreadLocal<FieldsReader> {
+class LPPAPI FieldsReaderLocal : public CloseableThreadLocal<FieldsReader> {
 public:
     FieldsReaderLocal(const SegmentReaderPtr& reader);
 
@@ -77,7 +77,7 @@ protected:
     virtual FieldsReaderPtr initialValue();
 };
 
-class SegmentReaderRef : public LuceneObject {
+class LPPAPI SegmentReaderRef : public LuceneObject {
 public:
     SegmentReaderRef();
     virtual ~SegmentReaderRef();
@@ -100,7 +100,7 @@ public:
 /// array is all that is needed for sharing between cloned readers.  The current norm referencing is for
 /// sharing between readers whereas the byte[] referencing is for copy on write which is independent of
 /// reader references (i.e. incRef, decRef).
-class Norm : public LuceneObject {
+class LPPAPI Norm : public LuceneObject {
 public:
     Norm();
     Norm(const SegmentReaderPtr& reader, const IndexInputPtr& in, int32_t number, int64_t normSeek);

--- a/src/core/include/_SimpleFSDirectory.h
+++ b/src/core/include/_SimpleFSDirectory.h
@@ -12,7 +12,7 @@
 
 namespace Lucene {
 
-class InputFile : public LuceneObject {
+class LPPAPI InputFile : public LuceneObject {
 public:
     InputFile(const String& path);
     virtual ~InputFile();
@@ -37,7 +37,7 @@ public:
     bool isValid();
 };
 
-class SimpleFSIndexInput : public BufferedIndexInput {
+class LPPAPI SimpleFSIndexInput : public BufferedIndexInput {
 public:
     SimpleFSIndexInput();
     SimpleFSIndexInput(const String& path, int32_t bufferSize, int32_t chunkSize);

--- a/src/test/include/MockRAMDirectory.h
+++ b/src/test/include/MockRAMDirectory.h
@@ -13,7 +13,7 @@
 namespace Lucene {
 
 /// This is a subclass of RAMDirectory that adds methods intended to be used only by unit tests.
-class MockRAMDirectory : public RAMDirectory {
+class LPPAPI MockRAMDirectory : public RAMDirectory {
 public:
     MockRAMDirectory();
     MockRAMDirectory(const DirectoryPtr& dir);

--- a/src/test/include/MockRAMOutputStream.h
+++ b/src/test/include/MockRAMOutputStream.h
@@ -14,7 +14,7 @@ namespace Lucene {
 
 /// Used by MockRAMDirectory to create an output stream that will throw an IOException on fake disk full, track max
 /// disk space actually used, and maybe throw random IOExceptions.
-class MockRAMOutputStream : public RAMOutputStream {
+class LPPAPI MockRAMOutputStream : public RAMOutputStream {
 public:
     /// Construct an empty output buffer.
     MockRAMOutputStream(const MockRAMDirectoryPtr& dir, const RAMFilePtr& f, const String& name);


### PR DESCRIPTION
added in missing LPPAPI tags to classes in header files.
this should now allow the proper building of shared libraries with
-fvisibility=hidden.