### PR TITLE
fixed test binary compilation on msvc

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1,11 +1,21 @@
 project(tester)
 
+
 ####################################
 # create test bin target
 ####################################
 add_executable(lucene++-tester)
 
+
+####################################
+# configure GTest
+####################################
+if(MSVC)
+  set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+endif()
+
 add_subdirectory(gtest)
+
 
 ####################################
 # src
@@ -22,13 +32,11 @@ file(GLOB_RECURSE tester_sources
   "util/*.cpp")
 
 file(GLOB_RECURSE test_headers
-    "${lucene++-tester_SOURCE_DIR}/../include/*.h"
     "${lucene++-tester_SOURCE_DIR}/include/*.h")
 
 target_sources(lucene++-tester
   PRIVATE
-    ${tester_sources}
-    ${test_headers})
+    ${tester_sources})
 
 
 ####################################
@@ -36,25 +44,31 @@ target_sources(lucene++-tester
 ####################################
 target_include_directories(lucene++-tester
   PUBLIC
+    $<BUILD_INTERFACE:${googletest_SOURCE_DIR}/googletest/include>
+    $<BUILD_INTERFACE:${Boost_INCLUDE_DIRS}>
+    $<BUILD_INTERFACE:${lucene++_SOURCE_DIR}/include/lucene++>
     $<BUILD_INTERFACE:${lucene++_BINARY_DIR}/include>
-    ${lucene++_SOURCE_DIR}/include/lucene++>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-
-    ${gtest_SOURCE_DIR}/include/gtest>
-    ${gtest_SOURCE_DIR}/include/gtest/internal>
-    ${core_SOURCE_DIR}/include>
-    ${contrib_SOURCE_DIR}/include>
-    ${Boost_INCLUDE_DIRS}>)
+    $<BUILD_INTERFACE:${core_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${contrib_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 
 
 ####################################
 # dependencies
 ####################################
-
 target_link_libraries(lucene++-tester
-    ${lucene_boost_libs}
+  PRIVATE
+    Boost::boost
+    Boost::date_time
+    Boost::filesystem
+    Boost::iostreams
+    Boost::regex
+    Boost::system
+    Boost::thread
     ZLIB::ZLIB
+    gtest_main
     gtest
+    
     lucene++::lucene++
     lucene++::lucene++-contrib)
 
@@ -63,6 +77,5 @@ target_link_libraries(lucene++-tester
 # link args
 ####################################
 target_compile_options(lucene++-tester PRIVATE -DLPP_EXPOSE_INTERNAL)
-target_compile_options(lucene++-tester PRIVATE -DLPP_BUILDING_LIB)
 
 cotire(lucene++-tester)

--- a/src/test/include/MockRAMDirectory.h
+++ b/src/test/include/MockRAMDirectory.h
@@ -13,7 +13,7 @@
 namespace Lucene {
 
 /// This is a subclass of RAMDirectory that adds methods intended to be used only by unit tests.
-class LPPAPI MockRAMDirectory : public RAMDirectory {
+class MockRAMDirectory : public RAMDirectory {
 public:
     MockRAMDirectory();
     MockRAMDirectory(const DirectoryPtr& dir);

--- a/src/test/include/MockRAMOutputStream.h
+++ b/src/test/include/MockRAMOutputStream.h
@@ -14,7 +14,7 @@ namespace Lucene {
 
 /// Used by MockRAMDirectory to create an output stream that will throw an IOException on fake disk full, track max
 /// disk space actually used, and maybe throw random IOExceptions.
-class LPPAPI MockRAMOutputStream : public RAMOutputStream {
+class MockRAMOutputStream : public RAMOutputStream {
 public:
     /// Construct an empty output buffer.
     MockRAMOutputStream(const MockRAMDirectoryPtr& dir, const RAMFilePtr& f, const String& name);

--- a/src/test/include/TestInc.h
+++ b/src/test/include/TestInc.h
@@ -4,7 +4,7 @@
 // or the GNU Lesser General Public License.
 /////////////////////////////////////////////////////////////////////////////
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(_WIN64)
 
 #include "targetver.h"
 


### PR DESCRIPTION
Fixes test binary compilation on msvc 
hosts. Requires https://github.com/luceneplusplus/LucenePlusPlus/pull/149