### PR TITLE
CMakeLists.txt: fix typo preventing lucene++-contrib library symlink …

### DIFF
--- a/src/contrib/CMakeLists.txt
+++ b/src/contrib/CMakeLists.txt
@@ -77,7 +77,7 @@ endif()
 ####################################
 target_compile_options(lucene++-contrib PRIVATE -DLPP_BUILDING_LIB)
 
-set_target_properties(lucene++
+set_target_properties(lucene++-contrib
   PROPERTIES
     COTIRE_CXX_PREFIX_HEADER_INIT "include/ContribInc.h"
     CXX_VISIBILITY_PRESET hidden


### PR DESCRIPTION
…from being created correctly

The SONAME/SOVERSION weren't evaluated and set correctly because of the wrong target name.

It took lots of time to find that typo :)