### PR TITLE
Fix various cmake issues:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
 endif()
 
 set(LIB_DESTINATION
-  "${CMAKE_INSTALL_FULL_LIBDIR}" CACHE STRING "Define lib output directory name")
+  "${CMAKE_INSTALL_LIBDIR}" CACHE STRING "Define lib output directory name")
 
 
 ####################################

--- a/src/config/CMakeLists.txt
+++ b/src/config/CMakeLists.txt
@@ -1,16 +1,16 @@
 ####################################
 # Set config vars
 ####################################
-set(core_libname, "lucene++")
-set(contrib_libname, "lucene++-contrib")
+set(core_libname "lucene++")
+set(contrib_libname "lucene++-contrib")
 
 set(
-    PACKAGE_CMAKE_INSTALL_INCLUDEDIR,
-    "${lucene++_INCLUDE_DIR}/lucene++/")
+    PACKAGE_CMAKE_INSTALL_INCLUDEDIR
+    "${CMAKE_INSTALL_INCLUDEDIR}/lucene++/")
 
 set(
-    PACKAGE_CMAKE_INSTALL_LIBDIR,
-    "${LIB_INSTALL_DIR}/cmake")
+    PACKAGE_CMAKE_INSTALL_LIBDIR
+    "${LIB_DESTINATION}")
 
 
 ####################################

--- a/src/config/contrib/CMakeLists.txt
+++ b/src/config/contrib/CMakeLists.txt
@@ -9,7 +9,7 @@ if(NOT WIN32)
   install(
     FILES
       "${CMAKE_CURRENT_BINARY_DIR}/liblucene++-contrib.pc"
-    DESTINATION "include/pkgconfig")
+    DESTINATION "${LIB_DESTINATION}/pkgconfig")
 endif()
 
 
@@ -19,7 +19,8 @@ endif()
 configure_package_config_file(
   "${CMAKE_CURRENT_SOURCE_DIR}/liblucene++-contribConfig.cmake.in"
   "${CMAKE_CURRENT_BINARY_DIR}/liblucene++-contribConfig.cmake"
-  INSTALL_DESTINATION "${LIB_DESTINATION}/cmake")
+  INSTALL_DESTINATION "${LIB_DESTINATION}/cmake/liblucene++-contrib"
+  PATH_VARS contrib_libname PACKAGE_CMAKE_INSTALL_INCLUDEDIR PACKAGE_CMAKE_INSTALL_LIBDIR)
 
 write_basic_package_version_file(
   "${CMAKE_CURRENT_BINARY_DIR}/liblucene++-contribConfigVersion.cmake"
@@ -30,4 +31,4 @@ install(
   FILES
     "${CMAKE_CURRENT_BINARY_DIR}/liblucene++-contribConfig.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/liblucene++-contribConfigVersion.cmake"
-  DESTINATION "include/cmake")
+  DESTINATION "${LIB_DESTINATION}/cmake/liblucene++-contrib")

--- a/src/config/contrib/liblucene++-contribConfig.cmake.in
+++ b/src/config/contrib/liblucene++-contribConfig.cmake.in
@@ -20,6 +20,6 @@ if (NOT DEFINED set_and_check)
 endif()
 
 
-set_and_check(liblucene++-contrib_INCLUDE_DIRS "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@/@contrib_libname@")
-set_and_check(liblucene++-contrib_LIBRARY_DIRS "@PACKAGE_CMAKE_INSTALL_LIBDIR@")
-set(liblucene++-contrib_LIBRARIES "@PACKAGE_CMAKE_INSTALL_LIBDIR@/@contrib_libname@")
+set_and_check(liblucene++-contrib_INCLUDE_DIRS "${PACKAGE_PREFIX_DIR}/@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
+set_and_check(liblucene++-contrib_LIBRARY_DIRS "${PACKAGE_PREFIX_DIR}/@PACKAGE_CMAKE_INSTALL_LIBDIR@")
+set(liblucene++-contrib_LIBRARIES "@contrib_libname@")

--- a/src/config/core/CMakeLists.txt
+++ b/src/config/core/CMakeLists.txt
@@ -9,7 +9,7 @@ if(NOT WIN32)
   install(
     FILES
       "${CMAKE_CURRENT_BINARY_DIR}/liblucene++.pc"
-    DESTINATION "include/pkgconfig")
+    DESTINATION "${LIB_DESTINATION}/pkgconfig")
 endif()
 
 
@@ -19,7 +19,8 @@ endif()
 configure_package_config_file(
   "${CMAKE_CURRENT_SOURCE_DIR}/liblucene++Config.cmake.in"
   "${CMAKE_CURRENT_BINARY_DIR}/liblucene++Config.cmake"
-  INSTALL_DESTINATION "${LIB_DESTINATION}/cmake")
+  INSTALL_DESTINATION "${LIB_DESTINATION}/cmake/liblucene++"
+  PATH_VARS core_libname PACKAGE_CMAKE_INSTALL_INCLUDEDIR PACKAGE_CMAKE_INSTALL_LIBDIR)
 
 write_basic_package_version_file(
   ${CMAKE_CURRENT_BINARY_DIR}/liblucene++ConfigVersion.cmake
@@ -30,4 +31,4 @@ install(
   FILES
     "${CMAKE_CURRENT_BINARY_DIR}/liblucene++Config.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/liblucene++ConfigVersion.cmake"
-  DESTINATION "include/cmake")
+  DESTINATION "${LIB_DESTINATION}/cmake/liblucene++")

--- a/src/config/core/liblucene++Config.cmake.in
+++ b/src/config/core/liblucene++Config.cmake.in
@@ -20,8 +20,8 @@ if (NOT DEFINED set_and_check)
 endif()
 
 
-set_and_check(liblucene++_INCLUDE_DIRS "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@/@core_libname@")
-set_and_check(liblucene++_LIBRARY_DIRS "@PACKAGE_CMAKE_INSTALL_LIBDIR@")
-set(liblucene++_LIBRARIES "@PACKAGE_CMAKE_INSTALL_LIBDIR@/@core_libname@")
+set_and_check(liblucene++_INCLUDE_DIRS "${PACKAGE_PREFIX_DIR}/@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
+set_and_check(liblucene++_LIBRARY_DIRS "${PACKAGE_PREFIX_DIR}/@PACKAGE_CMAKE_INSTALL_LIBDIR@")
+set(liblucene++_LIBRARIES "@core_libname@")
 
 


### PR DESCRIPTION
"CMAKE_INSTALL_FULL_LIBDIR" not being correctly evaluated and used
pkgconfig directory wrongly set to include instead of lib
cmake directory wrongly set to include instead of lib
core_libname contrib_libname PACKAGE_CMAKE_INSTALL_INCLUDEDIR PACKAGE_CMAKE_INSTALL_LIBDIR variables not being substituted to cmake.in files
cmake helpers not being correctly set