### PR TITLE
updated fpic definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ add_definitions(-DNOMINMAX)
 endif()
 
 if(NOT WIN32 AND NOT CMAKE_SYSTEM MATCHES "SunOS-5*.")
-  add_definitions(-fPIC)
+  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 endif()
 
 if(CYGWIN)


### PR DESCRIPTION
updated the cmake fpic definition. existing is "-fPIC" is not
compatible with clang.