### PR TITLE
Fix src/contrib/CMakeLists.txt

### DIFF
--- a/src/config/contrib/CMakeLists.txt
+++ b/src/config/contrib/CMakeLists.txt
@@ -9,7 +9,7 @@ if(NOT WIN32)
   install(
     FILES
       "${CMAKE_CURRENT_BINARY_DIR}/liblucene++-contrib.pc"
-    DESTINATION {${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 endif()
 
 

--- a/src/contrib/CMakeLists.txt
+++ b/src/contrib/CMakeLists.txt
@@ -93,6 +93,6 @@ install(TARGETS lucene++-contrib
 
 install(
   FILES ${contrib_headers}
-  LIBRARY DESTINATION "include/lucene++"
-  LIBRARY DESTINATION "src/contrib/include"
+  DESTINATION "include/lucene++"
+  DESTINATION "src/contrib/include"
   COMPONENT development-contrib)


### PR DESCRIPTION
Some devs report the keyword "LIBRARY“ leads to build failure. Removing "LIBRARY“ on line 96 and 97 can fix it.