### PR TITLE
Fix cmake errors

### DIFF
--- a/src/contrib/CMakeLists.txt
+++ b/src/contrib/CMakeLists.txt
@@ -94,5 +94,4 @@ install(TARGETS lucene++-contrib
 install(
   FILES ${contrib_headers}
   DESTINATION "include/lucene++"
-  DESTINATION "src/contrib/include"
   COMPONENT development-contrib)


### PR DESCRIPTION
Hi, when I execute cmake, I get the following error：
```
-- Found Boost components:
   date_time;filesystem;iostreams;regex;system;thread
-- Found ZLIB: /usr/lib64/libz.so (found version "1.2.7")
-- Found Threads: TRUE
-- C CXX target lucene++ cotired.
-- C CXX target lucene++-contrib cotired.
CMake Error at src/contrib/CMakeLists.txt:94 (install):
  install FILES given unknown argument "DESTINATION".
```

The cmake does not support multi DESTINATION in a install command, at the same time i think `DESTINATION "src/contrib/include"` is no need actually.