### PR TITLE
 Search performance optimization

### DIFF
--- a/include/lucene++/AbstractAllTermDocs.h
+++ b/include/lucene++/AbstractAllTermDocs.h
@@ -32,7 +32,7 @@ public:
     virtual int32_t doc();
     virtual int32_t freq();
     virtual bool next();
-    virtual int32_t read(Collection<int32_t> docs, Collection<int32_t> freqs);
+    virtual int32_t read(Collection<int32_t>& docs, Collection<int32_t>& freqs);
     virtual bool skipTo(int32_t target);
     virtual void close();
     virtual bool isDeleted(int32_t doc) = 0;

--- a/include/lucene++/Array.h
+++ b/include/lucene++/Array.h
@@ -100,7 +100,7 @@ public:
     }
 
     TYPE& operator[] (int32_t i) const {
-        BOOST_ASSERT(i >= 0 && i < array->size);
+        // BOOST_ASSERT(i >= 0 && i < array->size);
         return array->data[i];
     }
 

--- a/include/lucene++/Array.h
+++ b/include/lucene++/Array.h
@@ -100,7 +100,6 @@ public:
     }
 
     TYPE& operator[] (int32_t i) const {
-        // BOOST_ASSERT(i >= 0 && i < array->size);
         return array->data[i];
     }
 

--- a/include/lucene++/BooleanScorer.h
+++ b/include/lucene++/BooleanScorer.h
@@ -46,6 +46,7 @@ protected:
     int32_t minNrShouldMatch;
     int32_t end;
     BucketPtr current;
+    Bucket* __current = nullptr;
     int32_t doc;
 
 protected:
@@ -71,8 +72,10 @@ public:
 
 protected:
     BucketTableWeakPtr _bucketTable;
+    BucketTable* __bucketTable = nullptr;
     int32_t mask;
     ScorerWeakPtr _scorer;
+    Scorer* __scorer = nullptr;
 
 public:
     virtual void collect(int32_t doc);
@@ -121,6 +124,7 @@ public:
     int32_t bits; // used for bool constraints
     int32_t coord; // count of terms in score
     BucketWeakPtr _next; // next valid bucket
+    Bucket* __next = nullptr; // next valid bucket
 };
 
 /// A simple hash table of document scores within a range.
@@ -137,6 +141,7 @@ public:
 
     Collection<BucketPtr> buckets;
     BucketPtr first; // head of valid list
+    Bucket* __first = nullptr; // head of valid list
 
 public:
     CollectorPtr newCollector(int32_t mask);

--- a/include/lucene++/BufferedIndexInput.h
+++ b/include/lucene++/BufferedIndexInput.h
@@ -30,11 +30,17 @@ protected:
     int32_t bufferLength; // end of valid bytes
     int32_t bufferPosition; // next byte to read
     ByteArray buffer;
+    decltype(buffer.get()) __buffer;
 
 public:
     /// Reads and returns a single byte.
     /// @see IndexOutput#writeByte(uint8_t)
     virtual uint8_t readByte();
+
+    /// Reads an int stored in variable-length format.  Reads between one and five
+    /// bytes.  Smaller values take fewer bytes.  Negative numbers are not supported.
+    /// @see IndexOutput#writeVInt(int32_t)
+    virtual int32_t readVInt();
 
     /// Change the buffer size used by this IndexInput.
     void setBufferSize(int32_t newSize);

--- a/include/lucene++/Collection.h
+++ b/include/lucene++/Collection.h
@@ -193,6 +193,10 @@ public:
     bool operator!= (const this_type& other) {
         return (container != other.container);
     }
+
+    collection_type* get() {
+        return container.get();
+    }
 };
 
 template <typename TYPE>

--- a/include/lucene++/DirectoryReader.h
+++ b/include/lucene++/DirectoryReader.h
@@ -262,7 +262,7 @@ public:
 
     /// Attempts to read multiple entries from the enumeration, up to length of docs.
     /// Optimized implementation.
-    virtual int32_t read(Collection<int32_t> docs, Collection<int32_t> freqs);
+    virtual int32_t read(Collection<int32_t>& docs, Collection<int32_t>& freqs);
 
     /// Skips entries to the first beyond the current whose document number is greater than or equal to target.
     virtual bool skipTo(int32_t target);

--- a/include/lucene++/FilterIndexReader.h
+++ b/include/lucene++/FilterIndexReader.h
@@ -93,7 +93,7 @@ public:
     virtual int32_t doc();
     virtual int32_t freq();
     virtual bool next();
-    virtual int32_t read(Collection<int32_t> docs, Collection<int32_t> freqs);
+    virtual int32_t read(Collection<int32_t>& docs, Collection<int32_t>& freqs);
     virtual bool skipTo(int32_t target);
     virtual void close();
 };

--- a/include/lucene++/LuceneFactory.h
+++ b/include/lucene++/LuceneFactory.h
@@ -104,7 +104,11 @@ boost::shared_ptr<T> newInstance(A1 const& a1, A2 const& a2, A3 const& a3, A4 co
 
 template <class T>
 boost::shared_ptr<T> newLucene() {
-    boost::shared_ptr<T> instance(newInstance<T>());
+#if BOOST_VERSION <= 103800
+    boost::shared_ptr<T> instance = boost::shared_ptr<T>(new T);
+#else
+    boost::shared_ptr<T> instance = boost::make_shared<T>();
+#endif
     instance->initialize();
     return instance;
 }

--- a/include/lucene++/MiscUtils.h
+++ b/include/lucene++/MiscUtils.h
@@ -132,6 +132,14 @@ public:
     static int32_t unsignedShift(int32_t num, int32_t shift);
 };
 
+inline int64_t MiscUtils::unsignedShift(int64_t num, int64_t shift) {
+    return (shift & 0x3f) == 0 ? num : (((uint64_t)num >> 1) & 0x7fffffffffffffffLL) >> ((shift & 0x3f) - 1);
+}
+
+inline int32_t MiscUtils::unsignedShift(int32_t num, int32_t shift) {
+    return (shift & 0x1f) == 0 ? num : (((uint32_t)num >> 1) & 0x7fffffff) >> ((shift & 0x1f) - 1);
+}
+
 }
 
 #endif

--- a/include/lucene++/MultipleTermPositions.h
+++ b/include/lucene++/MultipleTermPositions.h
@@ -41,7 +41,7 @@ public:
     virtual void seek(const TermEnumPtr& termEnum);
 
     /// Not implemented.
-    virtual int32_t read(Collection<int32_t> docs, Collection<int32_t> freqs);
+    virtual int32_t read(Collection<int32_t>& docs, Collection<int32_t>& freqs);
 
     /// Not implemented.
     virtual ByteArray getPayload(ByteArray data, int32_t offset);

--- a/include/lucene++/PhrasePositions.h
+++ b/include/lucene++/PhrasePositions.h
@@ -25,7 +25,7 @@ public:
     int32_t count; // remaining pos in this doc
     int32_t offset; // position in phrase
     TermPositionsPtr tp; // stream of positions
-    PhrasePositionsPtr _next; // used to make lists
+    PhrasePositions* __next = nullptr; // used to make lists
     bool repeats; // there's other pp for same term (eg. query="1st word 2nd word"~1)
 
 public:

--- a/include/lucene++/PhraseQueue.h
+++ b/include/lucene++/PhraseQueue.h
@@ -10,8 +10,10 @@
 #include "PriorityQueue.h"
 
 namespace Lucene {
+// raw pointer 
+typedef PhrasePositions* PhrasePositionsStar;
 
-class PhraseQueue : public PriorityQueue<PhrasePositionsPtr> {
+class PhraseQueue : public PriorityQueue<PhrasePositionsStar> {
 public:
     PhraseQueue(int32_t size);
     virtual ~PhraseQueue();
@@ -19,7 +21,8 @@ public:
     LUCENE_CLASS(PhraseQueue);
 
 protected:
-    virtual bool lessThan(const PhrasePositionsPtr& first, const PhrasePositionsPtr& second);
+    virtual bool lessThan(const PhrasePositionsStar& first, const PhrasePositionsStar& second);
+
 };
 
 }

--- a/include/lucene++/PhraseScorer.h
+++ b/include/lucene++/PhraseScorer.h
@@ -36,8 +36,6 @@ protected:
     bool more;
     PhraseQueuePtr pq;
     std::vector<PhrasePositionsPtr> _holds;
-    // PhrasePositionsPtr first;
-    // PhrasePositionsPtr last;
     PhrasePositions* __first = nullptr;
     PhrasePositions* __last = nullptr;
 

--- a/include/lucene++/PhraseScorer.h
+++ b/include/lucene++/PhraseScorer.h
@@ -8,6 +8,7 @@
 #define PHRASESCORER_H
 
 #include "Scorer.h"
+#include <vector>
 
 namespace Lucene {
 
@@ -27,14 +28,18 @@ public:
 
 protected:
     WeightPtr weight;
+    Weight* __weight = nullptr;
     ByteArray norms;
     double value;
 
     bool firstTime;
     bool more;
     PhraseQueuePtr pq;
-    PhrasePositionsPtr first;
-    PhrasePositionsPtr last;
+    std::vector<PhrasePositionsPtr> _holds;
+    // PhrasePositionsPtr first;
+    // PhrasePositionsPtr last;
+    PhrasePositions* __first = nullptr;
+    PhrasePositions* __last = nullptr;
 
     double freq; // phrase frequency in current doc as computed by phraseFreq().
 

--- a/include/lucene++/SegmentTermDocs.h
+++ b/include/lucene++/SegmentTermDocs.h
@@ -20,10 +20,13 @@ public:
 
 protected:
     SegmentReaderWeakPtr _parent;
+    SegmentReader* __parent;
     IndexInputPtr _freqStream;
+    IndexInput* __freqStream;
     int32_t count;
     int32_t df;
     BitVectorPtr deletedDocs;
+    BitVector* __deletedDocs;
     int32_t _doc;
     int32_t _freq;
 
@@ -61,7 +64,7 @@ public:
     virtual bool next();
 
     /// Optimized implementation.
-    virtual int32_t read(Collection<int32_t> docs, Collection<int32_t> freqs);
+    virtual int32_t read(Collection<int32_t>& docs, Collection<int32_t>& freqs);
 
     /// Optimized implementation.
     virtual bool skipTo(int32_t target);
@@ -72,7 +75,7 @@ public:
 
 protected:
     virtual void skippingDoc();
-    virtual int32_t readNoTf(Collection<int32_t> docs, Collection<int32_t> freqs, int32_t length);
+    virtual int32_t readNoTf(Collection<int32_t>& docs, Collection<int32_t>& freqs, int32_t length);
 
     /// Overridden by SegmentTermPositions to skip in prox stream.
     virtual void skipProx(int64_t proxPointer, int32_t payloadLength);

--- a/include/lucene++/SegmentTermPositions.h
+++ b/include/lucene++/SegmentTermPositions.h
@@ -46,7 +46,7 @@ public:
     virtual bool next();
 
     /// Not supported
-    virtual int32_t read(Collection<int32_t> docs, Collection<int32_t> freqs);
+    virtual int32_t read(Collection<int32_t>& docs, Collection<int32_t>& freqs);
 
     /// Returns the length of the payload at the current term position.
     virtual int32_t getPayloadLength();

--- a/include/lucene++/Similarity.h
+++ b/include/lucene++/Similarity.h
@@ -434,8 +434,8 @@ public:
 protected:
     static const int32_t NO_DOC_ID_PROVIDED;
 
-protected:
-    static const Collection<double> NORM_TABLE();
+public:
+    static const Collection<double> NORM_TABLE;
 
 public:
     /// Return the default Similarity implementation used by indexing and search code.
@@ -450,7 +450,7 @@ public:
 
     /// Returns a table for decoding normalization bytes.
     /// @see #encodeNorm(double)
-    static const Collection<double> getNormDecoder();
+    static const Collection<double>& getNormDecoder();
 
     /// Compute the normalization value for a field, given the accumulated state of term processing for this
     /// field (see {@link FieldInvertState}).

--- a/include/lucene++/SloppyPhraseScorer.h
+++ b/include/lucene++/SloppyPhraseScorer.h
@@ -20,8 +20,6 @@ public:
 
 protected:
     int32_t slop;
-    // Collection<PhrasePositionsPtr> repeats;
-    // Collection<PhrasePositionsPtr> tmpPos; // for flipping repeating pps
     Collection<PhrasePositions*> repeats;
     Collection<PhrasePositions*> tmpPos; // for flipping repeating pps
     bool checkedRepeats;

--- a/include/lucene++/SloppyPhraseScorer.h
+++ b/include/lucene++/SloppyPhraseScorer.h
@@ -20,8 +20,10 @@ public:
 
 protected:
     int32_t slop;
-    Collection<PhrasePositionsPtr> repeats;
-    Collection<PhrasePositionsPtr> tmpPos; // for flipping repeating pps
+    // Collection<PhrasePositionsPtr> repeats;
+    // Collection<PhrasePositionsPtr> tmpPos; // for flipping repeating pps
+    Collection<PhrasePositions*> repeats;
+    Collection<PhrasePositions*> tmpPos; // for flipping repeating pps
     bool checkedRepeats;
 
 public:
@@ -42,7 +44,7 @@ public:
 protected:
     /// Flip pp2 and pp in the queue: pop until finding pp2, insert back all but pp2, insert pp back.
     /// Assumes: pp!=pp2, pp2 in pq, pp not in pq.  Called only when there are repeating pps.
-    PhrasePositionsPtr flip(const PhrasePositionsPtr& pp, const PhrasePositionsPtr& pp2);
+    PhrasePositions* flip(PhrasePositions* pp, PhrasePositions* pp2);
 
     /// Init PhrasePositions in place.
     /// There is a one time initialization for this scorer:
@@ -61,7 +63,7 @@ protected:
     /// of the same word would go elsewhere in the matched doc.
     /// @return null if differ (i.e. valid) otherwise return the higher offset PhrasePositions out of the first
     /// two PPs found to not differ.
-    PhrasePositionsPtr termPositionsDiffer(const PhrasePositionsPtr& pp);
+    PhrasePositions* termPositionsDiffer(PhrasePositions* pp);
 };
 
 }

--- a/include/lucene++/TermDocs.h
+++ b/include/lucene++/TermDocs.h
@@ -44,7 +44,7 @@ public:
     /// Attempts to read multiple entries from the enumeration, up to length of docs.  Document numbers are stored
     /// in docs, and term frequencies are stored in freqs.  Returns the number of entries read.  Zero is only
     /// returned when the stream has been exhausted.
-    virtual int32_t read(Collection<int32_t> docs, Collection<int32_t> freqs) = 0;
+    virtual int32_t read(Collection<int32_t>& docs, Collection<int32_t>& freqs) = 0;
 
     /// Skips entries to the first beyond the current whose document number is greater than or equal to target.
     /// Returns true if there is such an entry.

--- a/include/lucene++/TermScorer.h
+++ b/include/lucene++/TermScorer.h
@@ -27,13 +27,16 @@ public:
 
 protected:
     WeightPtr weight;
-    TermDocsPtr termDocs;
+    TermDocsPtr termDocs; // for malloc and free
+    TermDocs* __termDocs; // for work,   
     ByteArray norms;
     double weightValue;
     int32_t doc;
 
     Collection<int32_t> docs; // buffered doc numbers
+    decltype(docs.get()) __docs; // 
     Collection<int32_t> freqs; // buffered term freqs
+    decltype(freqs.get()) __freqs; // 
     
     int32_t freq;
     int32_t pointer;
@@ -70,7 +73,7 @@ public:
     }
 
 protected:
-    static const Collection<double> SIM_NORM_DECODER();
+    static const Collection<double>& SIM_NORM_DECODER();
 
     virtual bool score(const CollectorPtr& collector, int32_t max, int32_t firstDocID);
 };

--- a/include/lucene++/TopScoreDocCollector.h
+++ b/include/lucene++/TopScoreDocCollector.h
@@ -29,6 +29,7 @@ INTERNAL:
     ScoreDocPtr pqTop;
     int32_t docBase;
     ScorerWeakPtr _scorer;
+    Scorer* __scorer;
 
 public:
     /// Creates a new {@link TopScoreDocCollector} given the number of hits to collect and whether documents

--- a/src/contrib/include/MemoryIndex.h
+++ b/src/contrib/include/MemoryIndex.h
@@ -323,7 +323,7 @@ public:
     virtual int32_t doc();
     virtual int32_t freq();
     virtual bool next();
-    virtual int32_t read(Collection<int32_t> docs, Collection<int32_t> freqs);
+    virtual int32_t read(Collection<int32_t>& docs, Collection<int32_t>& freqs);
     virtual bool skipTo(int32_t target);
     virtual void close();
 

--- a/src/contrib/memory/MemoryIndex.cpp
+++ b/src/contrib/memory/MemoryIndex.cpp
@@ -569,7 +569,7 @@ bool MemoryIndexTermPositions::next() {
     return _next;
 }
 
-int32_t MemoryIndexTermPositions::read(Collection<int32_t> docs, Collection<int32_t> freqs) {
+int32_t MemoryIndexTermPositions::read(Collection<int32_t>& docs, Collection<int32_t>& freqs) {
     if (!hasNext) {
         return 0;
     }

--- a/src/core/include/_ParallelReader.h
+++ b/src/core/include/_ParallelReader.h
@@ -61,7 +61,7 @@ public:
     virtual void seek(const TermPtr& term);
     virtual void seek(const TermEnumPtr& termEnum);
     virtual bool next();
-    virtual int32_t read(Collection<int32_t> docs, Collection<int32_t> freqs);
+    virtual int32_t read(Collection<int32_t>& docs, Collection<int32_t>& freqs);
     virtual bool skipTo(int32_t target);
     virtual void close();
 };

--- a/src/core/index/AbstractAllTermDocs.cpp
+++ b/src/core/index/AbstractAllTermDocs.cpp
@@ -41,7 +41,7 @@ bool AbstractAllTermDocs::next() {
     return skipTo(_doc + 1);
 }
 
-int32_t AbstractAllTermDocs::read(Collection<int32_t> docs, Collection<int32_t> freqs) {
+int32_t AbstractAllTermDocs::read(Collection<int32_t>& docs, Collection<int32_t>& freqs) {
     int32_t length = docs.size();
     int32_t i = 0;
     while (i < length && _doc < maxDoc) {

--- a/src/core/index/DirectoryReader.cpp
+++ b/src/core/index/DirectoryReader.cpp
@@ -984,7 +984,7 @@ bool MultiTermDocs::next() {
     }
 }
 
-int32_t MultiTermDocs::read(Collection<int32_t> docs, Collection<int32_t> freqs) {
+int32_t MultiTermDocs::read(Collection<int32_t>& docs, Collection<int32_t>& freqs) {
     while (true) {
         while (!current) {
             if (pointer < readers.size()) { // try next segment

--- a/src/core/index/FilterIndexReader.cpp
+++ b/src/core/index/FilterIndexReader.cpp
@@ -194,7 +194,7 @@ bool FilterTermDocs::next() {
     return in->next();
 }
 
-int32_t FilterTermDocs::read(Collection<int32_t> docs, Collection<int32_t> freqs) {
+int32_t FilterTermDocs::read(Collection<int32_t>& docs, Collection<int32_t>& freqs) {
     return in->read(docs, freqs);
 }
 

--- a/src/core/index/MultipleTermPositions.cpp
+++ b/src/core/index/MultipleTermPositions.cpp
@@ -98,7 +98,7 @@ void MultipleTermPositions::seek(const TermEnumPtr& termEnum) {
     boost::throw_exception(UnsupportedOperationException());
 }
 
-int32_t MultipleTermPositions::read(Collection<int32_t> docs, Collection<int32_t> freqs) {
+int32_t MultipleTermPositions::read(Collection<int32_t>& docs, Collection<int32_t>& freqs) {
     boost::throw_exception(UnsupportedOperationException());
     return 0;
 }

--- a/src/core/index/ParallelReader.cpp
+++ b/src/core/index/ParallelReader.cpp
@@ -488,7 +488,7 @@ bool ParallelTermDocs::next() {
     return termDocs ? termDocs->next() : false;
 }
 
-int32_t ParallelTermDocs::read(Collection<int32_t> docs, Collection<int32_t> freqs) {
+int32_t ParallelTermDocs::read(Collection<int32_t>& docs, Collection<int32_t>& freqs) {
     return termDocs ? termDocs->read(docs, freqs) : 0;
 }
 

--- a/src/core/index/SegmentTermPositions.cpp
+++ b/src/core/index/SegmentTermPositions.cpp
@@ -88,7 +88,7 @@ bool SegmentTermPositions::next() {
     return false;
 }
 
-int32_t SegmentTermPositions::read(Collection<int32_t> docs, Collection<int32_t> freqs) {
+int32_t SegmentTermPositions::read(Collection<int32_t>& docs, Collection<int32_t>& freqs) {
     boost::throw_exception(UnsupportedOperationException(L"TermPositions does not support processing multiple documents in one call. Use TermDocs instead."));
     return 0;
 }

--- a/src/core/index/TermDocs.cpp
+++ b/src/core/index/TermDocs.cpp
@@ -37,7 +37,7 @@ bool TermDocs::next() {
     return false; // override
 }
 
-int32_t TermDocs::read(Collection<int32_t> docs, Collection<int32_t> freqs) {
+int32_t TermDocs::read(Collection<int32_t>& docs, Collection<int32_t>& freqs) {
     BOOST_ASSERT(false);
     return 0; // override
 }

--- a/src/core/search/DefaultSimilarity.cpp
+++ b/src/core/search/DefaultSimilarity.cpp
@@ -27,35 +27,35 @@ double DefaultSimilarity::computeNorm(const String& fieldName, const FieldInvert
     return (state->getBoost() * lengthNorm(fieldName, numTerms));
 }
 
-double DefaultSimilarity::lengthNorm(const String& fieldName, int32_t numTokens) {
+inline double DefaultSimilarity::lengthNorm(const String& fieldName, int32_t numTokens) {
     return (double)(1.0 / std::sqrt((double)numTokens));
 }
 
-double DefaultSimilarity::queryNorm(double sumOfSquaredWeights) {
+inline double DefaultSimilarity::queryNorm(double sumOfSquaredWeights) {
     return (double)(1.0 / std::sqrt(sumOfSquaredWeights));
 }
 
-double DefaultSimilarity::tf(double freq) {
+inline double DefaultSimilarity::tf(double freq) {
     return (double)std::sqrt(freq);
 }
 
-double DefaultSimilarity::sloppyFreq(int32_t distance) {
+inline double DefaultSimilarity::sloppyFreq(int32_t distance) {
     return (1.0 / (double)(distance + 1));
 }
 
-double DefaultSimilarity::idf(int32_t docFreq, int32_t numDocs) {
+inline double DefaultSimilarity::idf(int32_t docFreq, int32_t numDocs) {
     return (double)(std::log((double)numDocs / (double)(docFreq + 1)) + 1.0);
 }
 
-double DefaultSimilarity::coord(int32_t overlap, int32_t maxOverlap) {
+inline double DefaultSimilarity::coord(int32_t overlap, int32_t maxOverlap) {
     return (double)overlap / (double)maxOverlap;
 }
 
-void DefaultSimilarity::setDiscountOverlaps(bool v) {
+inline void DefaultSimilarity::setDiscountOverlaps(bool v) {
     discountOverlaps = v;
 }
 
-bool DefaultSimilarity::getDiscountOverlaps() {
+inline bool DefaultSimilarity::getDiscountOverlaps() {
     return discountOverlaps;
 }
 

--- a/src/core/search/ExactPhraseScorer.cpp
+++ b/src/core/search/ExactPhraseScorer.cpp
@@ -20,9 +20,9 @@ ExactPhraseScorer::~ExactPhraseScorer() {
 double ExactPhraseScorer::phraseFreq() {
     // sort list with pq
     pq->clear();
-    for (PhrasePositionsPtr pp(first); more && pp; pp = pp->_next) {
-        pp->firstPosition();
-        pq->add(pp); // build pq from list
+    for (auto* __pp = __first; more && __pp; __pp = __pp->__next) {
+        __pp->firstPosition();
+        pq->add(__pp);
     }
     pqToList(); // rebuild list from pq
 
@@ -30,16 +30,16 @@ double ExactPhraseScorer::phraseFreq() {
     // times all PhrasePosition's have exactly the same position.
     int32_t freq = 0;
     do {
-        while (first->position < last->position) { // scan forward in first
+        while (__first->position < __last->position) { // scan forward in first
             do {
-                if (!first->nextPosition()) {
+                if (!__first->nextPosition()) {
                     return freq;
                 }
-            } while (first->position < last->position);
+            } while (__first->position < __last->position);
             firstToLast();
         }
         ++freq; // all equal: a match
-    } while (last->nextPosition());
+    } while (__last->nextPosition());
 
     return freq;
 }

--- a/src/core/search/PhraseQueue.cpp
+++ b/src/core/search/PhraseQueue.cpp
@@ -10,24 +10,27 @@
 
 namespace Lucene {
 
-PhraseQueue::PhraseQueue(int32_t size) : PriorityQueue<PhrasePositionsPtr>(size) {
+PhraseQueue::PhraseQueue(int32_t size) : PriorityQueue<PhrasePositionsStar>(size) {
 }
 
 PhraseQueue::~PhraseQueue() {
 }
 
-bool PhraseQueue::lessThan(const PhrasePositionsPtr& first, const PhrasePositionsPtr& second) {
-    if (first->doc == second->doc) {
-        if (first->position == second->position) {
-            // same doc and pp.position, so decide by actual term positions.
-            // rely on: pp.position == tp.position - offset.
-            return first->offset < second->offset;
+inline bool PhraseQueue::lessThan(const PhrasePositionsStar& first, const PhrasePositionsStar& second) {
+    if (first && second) {
+        if (first->doc == second->doc) {
+            if (first->position == second->position) {
+                // same doc and pp.position, so decide by actual term positions.
+                // rely on: pp.position == tp.position - offset.
+                return first->offset < second->offset;
+            } else {
+                return first->position < second->position;
+            }
         } else {
-            return first->position < second->position;
+            return first->doc < second->doc;
         }
-    } else {
-        return first->doc < second->doc;
     }
+    return first ? false : true;
 }
 
 }

--- a/src/core/search/Scorer.cpp
+++ b/src/core/search/Scorer.cpp
@@ -24,7 +24,7 @@ namespace Lucene {
     SimilarityPtr Scorer::getSimilarity() {
         return similarity;
     }
-    
+
     void Scorer::score(const CollectorPtr& collector) {
         collector->setScorer(shared_from_this());
         int32_t doc;

--- a/src/core/search/Similarity.cpp
+++ b/src/core/search/Similarity.cpp
@@ -33,7 +33,7 @@ SimilarityPtr Similarity::getDefault() {
     return defaultImpl;
 }
 
-const Collection<double> Similarity::NORM_TABLE() {
+static const Collection<double> GEN_NORM_TABLE() {
     static Collection<double> _NORM_TABLE;
     if (!_NORM_TABLE) {
         _NORM_TABLE = Collection<double>::newInstance(256);
@@ -44,12 +44,14 @@ const Collection<double> Similarity::NORM_TABLE() {
     return _NORM_TABLE;
 }
 
+const Collection<double> Similarity::NORM_TABLE = GEN_NORM_TABLE();
+
 double Similarity::decodeNorm(uint8_t b) {
-    return NORM_TABLE()[b & 0xff];  // & 0xff maps negative bytes to positive above 127
+    return NORM_TABLE[b & 0xff];  // & 0xff maps negative bytes to positive above 127
 }
 
-const Collection<double> Similarity::getNormDecoder() {
-    return NORM_TABLE();
+const Collection<double>& Similarity::getNormDecoder() {
+    return NORM_TABLE;
 }
 
 double Similarity::computeNorm(const String& fieldName, const FieldInvertStatePtr& state) {

--- a/src/core/search/SloppyPhraseScorer.cpp
+++ b/src/core/search/SloppyPhraseScorer.cpp
@@ -12,6 +12,14 @@
 
 namespace Lucene {
 
+struct __luceneEquals {
+    inline bool operator()(const PhrasePositions* __first, const PhrasePositions* __second) const {
+        return __first ? (__second && __first == __second)  : (!__first && !__second);
+    }
+};
+
+typedef HashMap< PhrasePositions*, LuceneObjectPtr, luceneHash<PhrasePositions*>, __luceneEquals > __MapPhrasePositionsLuceneObject;
+
 SloppyPhraseScorer::SloppyPhraseScorer(const WeightPtr& weight, Collection<TermPositionsPtr> tps, Collection<int32_t> offsets, const SimilarityPtr& similarity, int32_t slop, ByteArray norms) : PhraseScorer(weight, tps, offsets, similarity, norms) {
     this->slop = slop;
     this->checkedRepeats = false;
@@ -26,24 +34,24 @@ double SloppyPhraseScorer::phraseFreq() {
     double freq = 0.0;
     bool done = (end < 0);
     while (!done) {
-        PhrasePositionsPtr pp(pq->pop());
-        int32_t start = pp->position;
+        auto* __pp = pq->pop();
+        int32_t start = __pp->position;
         int32_t next = pq->top()->position;
 
         bool tpsDiffer = true;
-        for (int32_t pos = start; pos <= next || !tpsDiffer; pos = pp->position) {
+        for (int32_t pos = start; pos <= next || !tpsDiffer; pos = __pp->position) {
             if (pos<=next && tpsDiffer) {
                 start = pos;    // advance pp to min window
             }
-            if (!pp->nextPosition()) {
+            if (!__pp->nextPosition()) {
                 done = true; // ran out of a term - done
                 break;
             }
 
-            PhrasePositionsPtr pp2;
-            tpsDiffer = (!pp->repeats || !(pp2 = termPositionsDiffer(pp)));
-            if (pp2 && pp2 != pp) {
-                pp = flip(pp, pp2);    // flip pp to pp2
+            PhrasePositions* __pp2 = nullptr;
+            tpsDiffer = (!__pp->repeats || !(__pp2 = termPositionsDiffer(__pp)));
+            if (__pp2 && __pp2 != __pp) {
+                __pp = flip(__pp, __pp2);    // flip pp to pp2
             }
         }
 
@@ -52,29 +60,29 @@ double SloppyPhraseScorer::phraseFreq() {
             freq += getSimilarity()->sloppyFreq(matchLength);    // score match
         }
 
-        if (pp->position > end) {
-            end = pp->position;
+        if (__pp->position > end) {
+            end = __pp->position;
         }
-        pq->add(pp); // restore pq
+        pq->add(__pp); // restore pq
     }
 
     return freq;
 }
 
-PhrasePositionsPtr SloppyPhraseScorer::flip(const PhrasePositionsPtr& pp, const PhrasePositionsPtr& pp2) {
+PhrasePositions* SloppyPhraseScorer::flip(PhrasePositions* __pp, PhrasePositions* __pp2) {
     int32_t n = 0;
-    PhrasePositionsPtr pp3;
+    PhrasePositions* __pp3;
     // pop until finding pp2
-    while ((pp3 = pq->pop()) != pp2) {
-        tmpPos[n++] = pp3;
+    while ((__pp3 = pq->pop()) != __pp2) {
+        tmpPos[n++] = __pp3;
     }
     // insert back all but pp2
     for (n--; n >= 0; --n) {
         pq->addOverflow(tmpPos[n]);
     }
     // insert pp back
-    pq->add(pp);
-    return pp2;
+    pq->add(__pp);
+    return __pp2;
 }
 
 int32_t SloppyPhraseScorer::initPhrasePositions() {
@@ -84,44 +92,44 @@ int32_t SloppyPhraseScorer::initPhrasePositions() {
     if (checkedRepeats && !repeats) {
         // build queue from list
         pq->clear();
-        for (PhrasePositionsPtr pp(first); pp; pp = pp->_next) {
-            pp->firstPosition();
-            if (pp->position > end) {
-                end = pp->position;
+        for (auto* __pp = __first; __pp; __pp = __pp->__next) {
+            __pp->firstPosition();
+            if (__pp->position > end) {
+                end = __pp->position;
             }
-            pq->add(pp); // build pq from list
+            pq->add(__pp); // build pq from list
         }
         return end;
     }
 
     // position the pp's
-    for (PhrasePositionsPtr pp(first); pp; pp = pp->_next) {
-        pp->firstPosition();
+    for (PhrasePositions* __pp = __first; __pp; __pp = __pp->__next) {
+        __pp->firstPosition();
     }
 
     // one time initialization for this scorer
     if (!checkedRepeats) {
         checkedRepeats = true;
         // check for repeats
-        MapPhrasePositionsLuceneObject m;
-        for (PhrasePositionsPtr pp(first); pp; pp = pp->_next) {
-            int32_t tpPos = pp->position + pp->offset;
-            for (PhrasePositionsPtr pp2(pp->_next); pp2; pp2 = pp2->_next) {
-                int32_t tpPos2 = pp2->position + pp2->offset;
+        __MapPhrasePositionsLuceneObject m;
+        for (auto* __pp = __first; __pp; __pp = __pp->__next) {
+            int32_t tpPos = __pp->position + __pp->offset;
+            for (auto* __pp2 = __pp->__next; __pp2; __pp2 = __pp2->__next) {
+                int32_t tpPos2 = __pp2->position + __pp2->offset;
                 if (tpPos2 == tpPos) {
                     if (!m) {
-                        m = MapPhrasePositionsLuceneObject::newInstance();
+                        m = __MapPhrasePositionsLuceneObject::newInstance();
                     }
-                    pp->repeats = true;
-                    pp2->repeats = true;
-                    m.put(pp, LuceneObjectPtr());
-                    m.put(pp2, LuceneObjectPtr());
+                    __pp->repeats = true;
+                    __pp2->repeats = true;
+                    m.put(__pp, LuceneObjectPtr());
+                    m.put(__pp2, LuceneObjectPtr());
                 }
             }
         }
         if (m) {
-            repeats = Collection<PhrasePositionsPtr>::newInstance();
-            for (MapPhrasePositionsLuceneObject::iterator key = m.begin(); key != m.end(); ++key) {
+            repeats = Collection<PhrasePositions*>::newInstance();
+            for (__MapPhrasePositionsLuceneObject::iterator key = m.begin(); key != m.end(); ++key) {
                 repeats.add(key->first);
             }
         }
@@ -129,8 +137,8 @@ int32_t SloppyPhraseScorer::initPhrasePositions() {
 
     // with repeats must advance some repeating pp's so they all start with differing tp's
     if (repeats) {
-        for (Collection<PhrasePositionsPtr>::iterator pp = repeats.begin(); pp != repeats.end(); ++pp) {
-            PhrasePositionsPtr pp2;
+        for (Collection<PhrasePositions*>::iterator pp = repeats.begin(); pp != repeats.end(); ++pp) {
+            PhrasePositions* pp2 = nullptr;
             while ((pp2 = termPositionsDiffer(*pp))) {
                 if (!pp2->nextPosition()) { // out of pps that do not differ, advance the pp with higher offset
                     return -1;    // ran out of a term - done
@@ -141,36 +149,36 @@ int32_t SloppyPhraseScorer::initPhrasePositions() {
 
     // build queue from list
     pq->clear();
-    for (PhrasePositionsPtr pp(first); pp; pp = pp->_next) {
-        if (pp->position > end) {
-            end = pp->position;
+    for (auto* __pp = __first; __pp; __pp = __pp->__next) {
+        if (__pp->position > end) {
+            end = __pp->position;
         }
-        pq->add(pp); // build pq from list
+        pq->add(__pp); // build pq from list
     }
 
     if (repeats) {
-        tmpPos = Collection<PhrasePositionsPtr>::newInstance(pq->size());
+        tmpPos = Collection<PhrasePositions*>::newInstance(pq->size());
     }
 
     return end;
 }
 
-PhrasePositionsPtr SloppyPhraseScorer::termPositionsDiffer(const PhrasePositionsPtr& pp) {
+PhrasePositions* SloppyPhraseScorer::termPositionsDiffer(PhrasePositions* __pp) {
     // Efficiency note: a more efficient implementation could keep a map between repeating pp's, so that if
     // pp1a, pp1b, pp1c are repeats term1, and pp2a, pp2b are repeats of term2, pp2a would only be checked
     // against pp2b but not against pp1a, pp1b, pp1c.  However this would complicate code, for a rather rare
     // case, so choice is to compromise here.
-    int32_t tpPos = pp->position + pp->offset;
-    for (Collection<PhrasePositionsPtr>::iterator pp2 = repeats.begin(); pp2 != repeats.end(); ++pp2) {
-        if (*pp2 == pp) {
+    int32_t tpPos = __pp->position + __pp->offset;
+    for (Collection<PhrasePositions*>::iterator pp2 = repeats.begin(); pp2 != repeats.end(); ++pp2) {
+        if (*pp2 == __pp) {
             continue;
         }
         int32_t tpPos2 = (*pp2)->position + (*pp2)->offset;
         if (tpPos2 == tpPos) {
-            return pp->offset > (*pp2)->offset ? pp : *pp2;    // do not differ: return the one with higher offset.
+            return __pp->offset > (*pp2)->offset ? __pp : *pp2;    // do not differ: return the one with higher offset.
         }
     }
-    return PhrasePositionsPtr();
+    return nullptr;
 }
 
 }

--- a/src/core/search/TermScorer.cpp
+++ b/src/core/search/TermScorer.cpp
@@ -18,25 +18,28 @@ const int32_t TermScorer::SCORE_CACHE_SIZE = 32;
 TermScorer::TermScorer(const WeightPtr& weight, const TermDocsPtr& td, const SimilarityPtr& similarity, ByteArray norms) : Scorer(similarity) {
     this->weight = weight;
     this->termDocs = td;
+    this->__termDocs = this->termDocs.get();
     this->norms = norms;
     this->weightValue = weight->getValue();
     this->doc = -1;
-    this->docs = Collection<int32_t>::newInstance(32);
-    this->freqs = Collection<int32_t>::newInstance(32);
+    this->docs = Collection<int32_t>::newInstance(123);
+    this->__docs = this->docs.get();
+    this->freqs = Collection<int32_t>::newInstance(128);
+    this->__freqs = this->freqs.get();
     this->pointer = 0;
     this->pointerMax = 0;
     this->scoreCache = Collection<double>::newInstance(SCORE_CACHE_SIZE);
 
     for (int32_t i = 0; i < SCORE_CACHE_SIZE; ++i) {
-        scoreCache[i] = getSimilarity()->tf(i) * weightValue;
+        scoreCache[i] = similarity->tf(i) * weightValue;
     }
 }
 
 TermScorer::~TermScorer() {
 }
 
-const Collection<double> TermScorer::SIM_NORM_DECODER() {
-    return Similarity::getNormDecoder();
+inline const Collection<double>& TermScorer::SIM_NORM_DECODER() {
+    return Similarity::NORM_TABLE;
 }
 
 void TermScorer::score(const CollectorPtr& collector) {
@@ -45,22 +48,23 @@ void TermScorer::score(const CollectorPtr& collector) {
 
 bool TermScorer::score(const CollectorPtr& collector, int32_t max, int32_t firstDocID) {
     // firstDocID is ignored since nextDoc() sets 'doc'
-    collector->setScorer(shared_from_this());
+    auto* __collector = collector.get();
+    __collector->setScorer(shared_from_this());
     while (doc < max) { // for docs in window
-        collector->collect(doc);
+        __collector->collect(doc);
 
         if (++pointer >= pointerMax) {
-            pointerMax = termDocs->read(docs, freqs); // refill buffers
+            pointerMax = __termDocs->read(docs, freqs); // refill buffers
             if (pointerMax != 0) {
                 pointer = 0;
             } else {
-                termDocs->close(); // close stream
+                __termDocs->close(); // close stream
                 doc = INT_MAX; // set to sentinel value
                 return false;
             }
         }
-        doc = docs[pointer];
-        freq = freqs[pointer];
+        doc = __docs->operator[](pointer);
+        freq = __freqs->operator[](pointer);
     }
     return true;
 }
@@ -72,45 +76,46 @@ int32_t TermScorer::docID() {
 int32_t TermScorer::nextDoc() {
     ++pointer;
     if (pointer >= pointerMax) {
-        pointerMax = termDocs->read(docs, freqs); // refill buffer
+        pointerMax = __termDocs->read(docs, freqs); // refill buffer
         if (pointerMax != 0) {
             pointer = 0;
         } else {
-            termDocs->close(); // close stream
+            __termDocs->close(); // close stream
             doc = NO_MORE_DOCS;
             return doc;
         }
     }
-    doc = docs[pointer];
-    freq = freqs[pointer];
+    doc = __docs->operator[](pointer);
+    freq = __freqs->operator[](pointer);
 
     return doc;
 }
 
 double TermScorer::score() {
     BOOST_ASSERT(doc != -1);
-    double raw = freq < SCORE_CACHE_SIZE ? scoreCache[freq] : getSimilarity()->tf(freq) * weightValue; // compute tf(f) * weight
+    double raw = freq < SCORE_CACHE_SIZE ? scoreCache[freq] : similarity->tf(freq) * weightValue; // compute tf(f) * weight
     return norms ? raw * SIM_NORM_DECODER()[norms[doc] & 0xff] : raw; // normalize for field
 }
 
 int32_t TermScorer::advance(int32_t target) {
     // first scan in cache
     for (++pointer; pointer < pointerMax; ++pointer) {
-        if (docs[pointer] >= target) {
-            doc = docs[pointer];
-            freq = freqs[pointer];
+        if (__docs->operator[](pointer) >= target) {
+            doc = __docs->operator[](pointer);
+            freq = __freqs->operator[](pointer);
             return doc;
         }
     }
 
     // not found in cache, seek underlying stream
-    bool result = termDocs->skipTo(target);
+    bool result = __termDocs->skipTo(target);
     if (result) {
         pointerMax = 1;
         pointer = 0;
-        doc = termDocs->doc();
-        docs[pointer] = doc;
-        freqs[pointer] = freq = termDocs->freq();
+        doc = __termDocs->doc();
+        __docs->operator[](pointer) = doc;
+        freq = __termDocs->freq();
+        __freqs->operator[](pointer) = freq;
     } else {
         doc = NO_MORE_DOCS;
     }

--- a/src/core/search/TopScoreDocCollector.cpp
+++ b/src/core/search/TopScoreDocCollector.cpp
@@ -60,6 +60,7 @@ void TopScoreDocCollector::setNextReader(const IndexReaderPtr& reader, int32_t d
 
 void TopScoreDocCollector::setScorer(const ScorerPtr& scorer) {
     this->_scorer = scorer;
+    this->__scorer = scorer.get();
 }
 
 InOrderTopScoreDocCollector::InOrderTopScoreDocCollector(int32_t numHits) : TopScoreDocCollector(numHits) {
@@ -69,7 +70,7 @@ InOrderTopScoreDocCollector::~InOrderTopScoreDocCollector() {
 }
 
 void InOrderTopScoreDocCollector::collect(int32_t doc) {
-    double score = ScorerPtr(_scorer)->score();
+    double score = __scorer->score();
 
     // This collector cannot handle these scores
     BOOST_ASSERT(score != -std::numeric_limits<double>::infinity());
@@ -98,7 +99,7 @@ OutOfOrderTopScoreDocCollector::~OutOfOrderTopScoreDocCollector() {
 }
 
 void OutOfOrderTopScoreDocCollector::collect(int32_t doc) {
-    double score = ScorerPtr(_scorer)->score();
+    double score = __scorer->score();
 
     // This collector cannot handle NaN
     BOOST_ASSERT(!MiscUtils::isNaN(score));

--- a/src/core/util/MiscUtils.cpp
+++ b/src/core/util/MiscUtils.cpp
@@ -124,12 +124,12 @@ bool MiscUtils::equalTypes(const LuceneObjectPtr& first, const LuceneObjectPtr& 
     return (typeid(firstRef) == typeid(secondRef));
 }
 
-int64_t MiscUtils::unsignedShift(int64_t num, int64_t shift) {
-    return (shift & 0x3f) == 0 ? num : (((uint64_t)num >> 1) & 0x7fffffffffffffffLL) >> ((shift & 0x3f) - 1);
-}
+// int64_t MiscUtils::unsignedShift(int64_t num, int64_t shift) {
+//     return (shift & 0x3f) == 0 ? num : (((uint64_t)num >> 1) & 0x7fffffffffffffffLL) >> ((shift & 0x3f) - 1);
+// }
 
-int32_t MiscUtils::unsignedShift(int32_t num, int32_t shift) {
-    return (shift & 0x1f) == 0 ? num : (((uint32_t)num >> 1) & 0x7fffffff) >> ((shift & 0x1f) - 1);
-}
+// int32_t MiscUtils::unsignedShift(int32_t num, int32_t shift) {
+//     return (shift & 0x1f) == 0 ? num : (((uint32_t)num >> 1) & 0x7fffffff) >> ((shift & 0x1f) - 1);
+// }
 
 }

--- a/src/core/util/MiscUtils.cpp
+++ b/src/core/util/MiscUtils.cpp
@@ -124,12 +124,4 @@ bool MiscUtils::equalTypes(const LuceneObjectPtr& first, const LuceneObjectPtr& 
     return (typeid(firstRef) == typeid(secondRef));
 }
 
-// int64_t MiscUtils::unsignedShift(int64_t num, int64_t shift) {
-//     return (shift & 0x3f) == 0 ? num : (((uint64_t)num >> 1) & 0x7fffffffffffffffLL) >> ((shift & 0x3f) - 1);
-// }
-
-// int32_t MiscUtils::unsignedShift(int32_t num, int32_t shift) {
-//     return (shift & 0x1f) == 0 ? num : (((uint32_t)num >> 1) & 0x7fffffff) >> ((shift & 0x1f) - 1);
-// }
-
 }


### PR DESCRIPTION
We made the following changes:
1. Use raw pointers instead of weak_ptr
2. The shared_ptr is used as memory management, and the raw pointer is used as the real worker
3. Optimized unreasonable function calls
4. parameter references
5. Simple functions are inlined
6. Overwrite BufferedIndexInput::readVInt()

https://github.com/luceneplusplus/LucenePlusPlus/issues/178

@alanw  PTAL