### PR TITLE
Add LPPAPI to Exception Template to fix it's visibility on mac

### DIFF
--- a/include/lucene++/LuceneException.h
+++ b/include/lucene++/LuceneException.h
@@ -64,7 +64,7 @@ public:
 };
 
 template <class ParentException, LuceneException::ExceptionType Type>
-class ExceptionTemplate : public ParentException {
+class LPPAPI ExceptionTemplate : public ParentException {
 public:
     ExceptionTemplate(const String& error = EmptyString, LuceneException::ExceptionType type = Type) : ParentException(error, type) {
     }


### PR DESCRIPTION
Fix for issue https://github.com/luceneplusplus/LucenePlusPlus/issues/182 that ensures that the Exception Template visibility is set correctly which fixes all failing tests on mac.