### PR TITLE
Update DefaultSimilarity.cpp

### DIFF
--- a/src/core/search/DefaultSimilarity.cpp
+++ b/src/core/search/DefaultSimilarity.cpp
@@ -27,35 +27,35 @@ double DefaultSimilarity::computeNorm(const String& fieldName, const FieldInvert
     return (state->getBoost() * lengthNorm(fieldName, numTerms));
 }
 
-inline double DefaultSimilarity::lengthNorm(const String& fieldName, int32_t numTokens) {
+double DefaultSimilarity::lengthNorm(const String& fieldName, int32_t numTokens) {
     return (double)(1.0 / std::sqrt((double)numTokens));
 }
 
-inline double DefaultSimilarity::queryNorm(double sumOfSquaredWeights) {
+double DefaultSimilarity::queryNorm(double sumOfSquaredWeights) {
     return (double)(1.0 / std::sqrt(sumOfSquaredWeights));
 }
 
-inline double DefaultSimilarity::tf(double freq) {
+double DefaultSimilarity::tf(double freq) {
     return (double)std::sqrt(freq);
 }
 
-inline double DefaultSimilarity::sloppyFreq(int32_t distance) {
+double DefaultSimilarity::sloppyFreq(int32_t distance) {
     return (1.0 / (double)(distance + 1));
 }
 
-inline double DefaultSimilarity::idf(int32_t docFreq, int32_t numDocs) {
+double DefaultSimilarity::idf(int32_t docFreq, int32_t numDocs) {
     return (double)(std::log((double)numDocs / (double)(docFreq + 1)) + 1.0);
 }
 
-inline double DefaultSimilarity::coord(int32_t overlap, int32_t maxOverlap) {
+double DefaultSimilarity::coord(int32_t overlap, int32_t maxOverlap) {
     return (double)overlap / (double)maxOverlap;
 }
 
-inline void DefaultSimilarity::setDiscountOverlaps(bool v) {
+void DefaultSimilarity::setDiscountOverlaps(bool v) {
     discountOverlaps = v;
 }
 
-inline bool DefaultSimilarity::getDiscountOverlaps() {
+bool DefaultSimilarity::getDiscountOverlaps() {
     return discountOverlaps;
 }
 


### PR DESCRIPTION
This fixes a linker failure when building tests (lto related?) https://launchpadlibrarian.net/715939877/buildlog_ubuntu-noble-amd64.lucene++_3.0.9-1_BUILDING.txt.gz

/usr/bin/c++ -g -O2 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -ffile-prefix-map=/<<PKGBUILDDIR>>=. -flto=auto -ffat-lto-objects -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -fdebug-prefix-map=/<<PKGBUILDDIR>>=/usr/src/lucene++-3.0.9-1 -Wdate-time -D_FORTIFY_SOURCE=3 -O2 -g -DNDEBUG -Wl,-Bsymbolic-functions -flto=auto -ffat-lto-objects -Wl,-z,relro "CMakeFiles/lucene++-tester.dir/analysis/AnalyzersTest.cpp.o" "CMakeFiles/lucene++-tester.dir/analysis/BaseTokenStreamFixture.cpp.o" "CMakeFiles/lucene++-tester.dir/analysis/CachingTokenFilterTest.cpp.o" "CMakeFiles/lucene++-tester.dir/analysis/CharFilterTest.cpp.o" "CMakeFiles/lucene++-tester.dir/analysis/KeywordAnalyzerTest.cpp.o" "CMakeFiles/lucene++-tester.dir/analysis/LengthFilterTest.cpp.o" "CMakeFiles/lucene++-tester.dir/analysis/MappingCharFilterTest.cpp.o" "CMakeFiles/lucene++-tester.dir/analysis/NumericTokenStreamTest.cpp.o" "CMakeFiles/lucene++-tester.dir/analysis/PerFieldAnalzyerWrapperTest.cpp.o" "CMakeFiles/lucene++-tester.dir/analysis/StopAnalyzerTest.cpp.o" "CMakeFiles/lucene++-tester.dir/analysis/StopFilterTest.cpp.o" "CMakeFiles/lucene++-tester.dir/analysis/TeeSinkTokenFilterTest.cpp.o" "CMakeFiles/lucene++-tester.dir/analysis/TokenTest.cpp.o" "CMakeFiles/lucene++-tester.dir/analysis/standard/StandardAnalyzerTest.cpp.o" "CMakeFiles/lucene++-tester.dir/analysis/tokenattributes/SimpleAttributeTest.cpp.o" "CMakeFiles/lucene++-tester.dir/analysis/tokenattributes/TermAttributeTest.cpp.o" "CMakeFiles/lucene++-tester.dir/contrib/analyzers/common/analysis/ar/ArabicAnalyzerTest.cpp.o" "CMakeFiles/lucene++-tester.dir/contrib/analyzers/common/analysis/ar/ArabicNormalizationFilterTest.cpp.o" "CMakeFiles/lucene++-tester.dir/contrib/analyzers/common/analysis/ar/ArabicStemFilterTest.cpp.o" "CMakeFiles/lucene++-tester.dir/contrib/analyzers/common/analysis/br/BrazilianStemmerTest.cpp.o" "CMakeFiles/lucene++-tester.dir/contrib/analyzers/common/analysis/cjk/CJKTokenizerTest.cpp.o" "CMakeFiles/lucene++-tester.dir/contrib/analyzers/common/analysis/cn/ChineseTokenizerTest.cpp.o" "CMakeFiles/lucene++-tester.dir/contrib/analyzers/common/analysis/cz/CzechAnalyzerTest.cpp.o" "CMakeFiles/lucene++-tester.dir/contrib/analyzers/common/analysis/de/GermanStemFilterTest.cpp.o" "CMakeFiles/lucene++-tester.dir/contrib/analyzers/common/analysis/el/GreekAnalyzerTest.cpp.o" "CMakeFiles/lucene++-tester.dir/contrib/analyzers/common/analysis/fa/PersianAnalyzerTest.cpp.o" "CMakeFiles/lucene++-tester.dir/contrib/analyzers/common/analysis/fa/PersianNormalizationFilterTest.cpp.o" "CMakeFiles/lucene++-tester.dir/contrib/analyzers/common/analysis/fr/ElisionTest.cpp.o" "CMakeFiles/lucene++-tester.dir/contrib/analyzers/common/analysis/fr/FrenchAnalyzerTest.cpp.o" "CMakeFiles/lucene++-tester.dir/contrib/analyzers/common/analysis/nl/DutchStemmerTest.cpp.o" "CMakeFiles/lucene++-tester.dir/contrib/analyzers/common/analysis/reverse/ReverseStringFilterTest.cpp.o" "CMakeFiles/lucene++-tester.dir/contrib/analyzers/common/analysis/ru/RussianAnalyzerTest.cpp.o" "CMakeFiles/lucene++-tester.dir/contrib/analyzers/common/analysis/ru/RussianStemTest.cpp.o" "CMakeFiles/lucene++-tester.dir/contrib/highlighter/HighlighterTest.cpp.o" "CMakeFiles/lucene++-tester.dir/contrib/memory/MemoryIndexTest.cpp.o" "CMakeFiles/lucene++-tester.dir/contrib/snowball/SnowballTest.cpp.o" "CMakeFiles/lucene++-tester.dir/document/BinaryDocumentTest.cpp.o" "CMakeFiles/lucene++-tester.dir/document/DateFieldTest.cpp.o" "CMakeFiles/lucene++-tester.dir/document/DateToolsTest.cpp.o" "CMakeFiles/lucene++-tester.dir/document/DocumentTest.cpp.o" "CMakeFiles/lucene++-tester.dir/document/NumberToolsTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/AddIndexesNoOptimizeTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/AtomicUpdateTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/BackwardsCompatibilityTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/ByteSlicesTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/CheckIndexTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/CompoundFileTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/ConcurrentMergeSchedulerTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/CrashTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/DeletionPolicyTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/DirectoryReaderTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/DocHelper.cpp.o" "CMakeFiles/lucene++-tester.dir/index/DocTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/DocumentWriterTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/FieldInfosTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/FieldsReaderTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/FilterIndexReaderTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/IndexCommitTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/IndexFileDeleterTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/IndexInputTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/IndexReaderCloneNormsTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/IndexReaderCloneTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/IndexReaderReopenTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/IndexReaderTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/IndexWriterDeleteTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/IndexWriterExceptionsTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/IndexWriterLockReleaseTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/IndexWriterMergePolicyTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/IndexWriterMergingTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/IndexWriterReaderTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/IndexWriterTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/LazyBugTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/LazyProxSkippingTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/MockIndexInput.cpp.o" "CMakeFiles/lucene++-tester.dir/index/MultiLevelSkipListTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/MultiReaderTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/NRTReaderWithThreadsTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/NormsTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/OmitTfTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/ParallelReaderEmptyIndexTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/ParallelReaderTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/ParallelTermEnumTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/PayloadsTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/PositionBasedTermVectorMapperTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/SegmentMergerTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/SegmentReaderTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/SegmentTermDocsTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/SegmentTermEnumTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/SnapshotDeletionPolicyTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/StressIndexingTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/TermDocsPerfTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/TermTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/TermVectorsReaderTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/ThreadedOptimizeTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/TransactionRollbackTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/TransactionsTest.cpp.o" "CMakeFiles/lucene++-tester.dir/index/WordlistLoaderTest.cpp.o" "CMakeFiles/lucene++-tester.dir/main/main.cpp.o" "CMakeFiles/lucene++-tester.dir/queryparser/MultiAnalyzerTest.cpp.o" "CMakeFiles/lucene++-tester.dir/queryparser/MultiFieldQueryParserTest.cpp.o" "CMakeFiles/lucene++-tester.dir/queryparser/QueryParserTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/BaseTestRangeFilterFixture.cpp.o" "CMakeFiles/lucene++-tester.dir/search/BaseTestRangeFilterTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/Boolean2Test.cpp.o" "CMakeFiles/lucene++-tester.dir/search/BooleanMinShouldMatchTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/BooleanOrTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/BooleanPrefixQueryTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/BooleanQueryTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/BooleanScorerTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/CachingSpanFilterTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/CachingWrapperFilterTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/CheckHits.cpp.o" "CMakeFiles/lucene++-tester.dir/search/ComplexExplanationsOfNonMatchesTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/ComplexExplanationsTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/CustomSearcherSortTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/DateFilterTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/DateSortTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/DisjunctionMaxQueryTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/DocBoostTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/DocIdSetTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/ElevationComparatorTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/ExplanationsFixture.cpp.o" "CMakeFiles/lucene++-tester.dir/search/FieldCacheRangeFilterTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/FieldCacheTermsFilterTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/FieldCacheTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/FilteredQueryTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/FilteredSearchTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/FuzzyQueryTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/MatchAllDocsQueryTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/MockFilter.cpp.o" "CMakeFiles/lucene++-tester.dir/search/MultiPhraseQueryTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/MultiSearcherRankingTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/MultiSearcherTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/MultiTermConstantScoreTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/MultiThreadTermVectorsTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/MultiValuedNumericRangeQueryTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/NotTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/NumericRangeQuery32Test.cpp.o" "CMakeFiles/lucene++-tester.dir/search/NumericRangeQuery64Test.cpp.o" "CMakeFiles/lucene++-tester.dir/search/ParallelMultiSearcherTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/PhrasePrefixQueryTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/PhraseQueryTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/PositionIncrementTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/PositiveScoresOnlyCollectorTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/PrefixFilterTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/PrefixInBooleanQueryTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/PrefixQueryTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/QueryTermVectorTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/QueryUtils.cpp.o" "CMakeFiles/lucene++-tester.dir/search/QueryWrapperFilterTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/ScoreCachingWrappingScorerTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/ScorerPerfTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/SearchForDuplicatesTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/SearchTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/SetNormTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/SimilarityTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/SimpleExplanationsOfNonMatchesTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/SimpleExplanationsTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/SloppyPhraseQueryTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/SortTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/SpanQueryFilterTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/TermRangeFilterTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/TermRangeQueryTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/TermScorerTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/TermVectorsTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/ThreadSafeTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/TimeLimitingCollectorTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/TopDocsCollectorTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/TopScoreDocCollectorTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/WildcardTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/function/CustomScoreQueryTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/function/DocValuesTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/function/FieldScoreQueryTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/function/FunctionFixture.cpp.o" "CMakeFiles/lucene++-tester.dir/search/function/OrdValuesTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/payloads/PayloadHelper.cpp.o" "CMakeFiles/lucene++-tester.dir/search/payloads/PayloadNearQueryTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/payloads/PayloadTermQueryTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/spans/BasicSpansTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/spans/FieldMaskingSpanQueryTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/spans/NearSpansOrderedTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/spans/PayloadSpansTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/spans/SpanExplanationsTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/spans/SpansAdvanced2Test.cpp.o" "CMakeFiles/lucene++-tester.dir/search/spans/SpansAdvancedTest.cpp.o" "CMakeFiles/lucene++-tester.dir/search/spans/SpansTest.cpp.o" "CMakeFiles/lucene++-tester.dir/store/BufferedIndexInputTest.cpp.o" "CMakeFiles/lucene++-tester.dir/store/BufferedIndexOutputTest.cpp.o" "CMakeFiles/lucene++-tester.dir/store/DirectoryTest.cpp.o" "CMakeFiles/lucene++-tester.dir/store/FileSwitchDirectoryTest.cpp.o" "CMakeFiles/lucene++-tester.dir/store/IndexOutputTest.cpp.o" "CMakeFiles/lucene++-tester.dir/store/LockFactoryTest.cpp.o" "CMakeFiles/lucene++-tester.dir/store/MMapDirectoryTest.cpp.o" "CMakeFiles/lucene++-tester.dir/store/MockFSDirectory.cpp.o" "CMakeFiles/lucene++-tester.dir/store/MockLock.cpp.o" "CMakeFiles/lucene++-tester.dir/store/MockLockFactory.cpp.o" "CMakeFiles/lucene++-tester.dir/store/MockRAMDirectory.cpp.o" "CMakeFiles/lucene++-tester.dir/store/MockRAMInputStream.cpp.o" "CMakeFiles/lucene++-tester.dir/store/MockRAMOutputStream.cpp.o" "CMakeFiles/lucene++-tester.dir/store/RAMDirectoryTest.cpp.o" "CMakeFiles/lucene++-tester.dir/util/AttributeSourceTest.cpp.o" "CMakeFiles/lucene++-tester.dir/util/Base64Test.cpp.o" "CMakeFiles/lucene++-tester.dir/util/BitVectorTest.cpp.o" "CMakeFiles/lucene++-tester.dir/util/BufferedReaderTest.cpp.o" "CMakeFiles/lucene++-tester.dir/util/CloseableThreadLocalTest.cpp.o" "CMakeFiles/lucene++-tester.dir/util/CompressionToolsTest.cpp.o" "CMakeFiles/lucene++-tester.dir/util/FieldCacheSanityCheckerTest.cpp.o" "CMakeFiles/lucene++-tester.dir/util/FileReaderTest.cpp.o" "CMakeFiles/lucene++-tester.dir/util/FileUtilsTest.cpp.o" "CMakeFiles/lucene++-tester.dir/util/InputStreamReaderTest.cpp.o" "CMakeFiles/lucene++-tester.dir/util/LuceneGlobalFixture.cpp.o" "CMakeFiles/lucene++-tester.dir/util/LuceneTestFixture.cpp.o" "CMakeFiles/lucene++-tester.dir/util/NumericUtilsTest.cpp.o" "CMakeFiles/lucene++-tester.dir/util/OpenBitSetTest.cpp.o" "CMakeFiles/lucene++-tester.dir/util/PriorityQueueTest.cpp.o" "CMakeFiles/lucene++-tester.dir/util/SimpleLRUCacheTest.cpp.o" "CMakeFiles/lucene++-tester.dir/util/SortedVIntListTest.cpp.o" "CMakeFiles/lucene++-tester.dir/util/StringReaderTest.cpp.o" "CMakeFiles/lucene++-tester.dir/util/StringUtilsTest.cpp.o" "CMakeFiles/lucene++-tester.dir/util/TestUtils.cpp.o" "CMakeFiles/lucene++-tester.dir/util/VersionTest.cpp.o" -o lucene++-tester  -Wl,-rpath,/<<PKGBUILDDIR>>/obj-x86_64-linux-gnu/src/contrib:/<<PKGBUILDDIR>>/obj-x86_64-linux-gnu/src/core /usr/lib/x86_64-linux-gnu/libz.so ../../lib/libgtest_main.a ../../lib/libgtest.a ../contrib/liblucene++-contrib.so.3.0.9 ../core/liblucene++.so.3.0.9 /usr/lib/x86_64-linux-gnu/libboost_date_time.so.1.83.0 /usr/lib/x86_64-linux-gnu/libboost_filesystem.so.1.83.0 /usr/lib/x86_64-linux-gnu/libboost_iostreams.so.1.83.0 /usr/lib/x86_64-linux-gnu/libboost_regex.so.1.83.0 /usr/lib/x86_64-linux-gnu/libboost_system.so.1.83.0 /usr/lib/x86_64-linux-gnu/libboost_thread.so.1.83.0 /usr/lib/x86_64-linux-gnu/libboost_atomic.so.1.83.0 /usr/lib/x86_64-linux-gnu/libz.so  /usr/src/lucene++-3.0.9-1/src/test/index/AtomicUpdateTest.cpp:27:7: warning: type ‘struct MockIndexWriter’ violates the C++ One Definition Rule [-Wodr] /usr/src/lucene++-3.0.9-1/src/test/index/IndexWriterExceptionsTest.cpp:122:7: note: a different type is defined in another translation unit /usr/src/lucene++-3.0.9-1/src/test/index/AtomicUpdateTest.cpp:37:15: note: the first difference of corresponding definitions is field ‘random’ /usr/src/lucene++-3.0.9-1/src/test/index/IndexWriterExceptionsTest.cpp:132:15: note: a field with different name is defined in another translation unit /usr/src/lucene++-3.0.9-1/src/test/store/IndexOutputTest.cpp:118:7: warning: type ‘struct SourceIndexInput’ violates the C++ One Definition Rule [-Wodr] /usr/src/lucene++-3.0.9-1/src/test/store/BufferedIndexOutputTest.cpp:100:7: note: a type with the same name but different base type is defined in another translation unit /usr/src/lucene++-3.0.9-1/include/lucene++/IndexInput.h:17:14: note: type name ‘Lucene::IndexInput’ should match type name ‘Lucene::BufferedIndexInput’ /usr/src/lucene++-3.0.9-1/include/lucene++/BufferedIndexInput.h:15:14: note: the incompatible type is defined here /usr/src/lucene++-3.0.9-1/src/test/store/IndexOutputTest.cpp:146:27: warning: type of ‘clone’ does not match original declaration [-Wlto-type-mismatch] /usr/src/lucene++-3.0.9-1/src/test/store/BufferedIndexOutputTest.cpp:117:27: note: ‘clone’ was previously declared here /usr/src/lucene++-3.0.9-1/src/test/store/BufferedIndexOutputTest.cpp:117:27: note: code may be misoptimized unless ‘-fno-strict-aliasing’ is used /usr/src/lucene++-3.0.9-1/src/test/store/IndexOutputTest.cpp:142:21: warning: type of ‘length’ does not match original declaration [-Wlto-type-mismatch] /usr/src/lucene++-3.0.9-1/src/test/store/BufferedIndexOutputTest.cpp:113:21: note: ‘length’ was previously declared here /usr/src/lucene++-3.0.9-1/src/test/store/BufferedIndexOutputTest.cpp:113:21: note: code may be misoptimized unless ‘-fno-strict-aliasing’ is used /usr/src/lucene++-3.0.9-1/src/test/search/ScorerPerfTest.cpp:27:7: warning: virtual table of type ‘struct CountingHitCollector’ violates one definition rule [-Wodr] /usr/src/lucene++-3.0.9-1/src/test/index/OmitTfTest.cpp:88:7: note: the conflicting type defined in another translation unit /usr/src/lucene++-3.0.9-1/src/test/index/OmitTfTest.cpp:99:5: note: virtual method ‘getClassName’ /usr/src/lucene++-3.0.9-1/include/lucene++/Collector.h:103:5: note: ought to match virtual method ‘getClassName’ but does not /usr/src/lucene++-3.0.9-1/src/test/index/IndexReaderCloneNormsTest.cpp:25:7: warning: virtual table of type ‘struct SimilarityOne’ violates one definition rule [-Wodr] /usr/src/lucene++-3.0.9-1/src/test/index/IndexReaderCloneNormsTest.cpp:25:7: note: the conflicting type defined in another translation unit /usr/src/lucene++-3.0.9-1/include/lucene++/DefaultSimilarity.h:20:5: note: virtual method ‘getClassName’ /usr/src/lucene++-3.0.9-1/src/test/index/NormsTest.cpp:26:5: note: ought to match virtual method ‘getClassName’ but does not /usr/src/lucene++-3.0.9-1/src/test/store/BufferedIndexOutputTest.cpp:100:7: warning: type ‘struct SourceIndexInput’ violates the C++ One Definition Rule [-Wodr] /usr/src/lucene++-3.0.9-1/src/test/store/BufferedIndexOutputTest.cpp:100:7: note: a type with the same name but different base type is defined in another translation unit /usr/src/lucene++-3.0.9-1/include/lucene++/IndexInput.h:17:14: note: type name ‘Lucene::IndexInput’ should match type name ‘Lucene::BufferedIndexInput’ /usr/src/lucene++-3.0.9-1/include/lucene++/BufferedIndexInput.h:15:14: note: the incompatible type is defined here /usr/bin/ld: /tmp/ccUJivoA.ltrans35.ltrans.o:(.data.rel.ro+0x558): undefined reference to `Lucene::DefaultSimilarity::queryNorm(double)' /usr/bin/ld: /tmp/ccUJivoA.ltrans35.ltrans.o:(.data.rel.ro+0x568): undefined reference to `Lucene::DefaultSimilarity::sloppyFreq(int)' /usr/bin/ld: /tmp/ccUJivoA.ltrans35.ltrans.o:(.data.rel.ro+0x570): undefined reference to `Lucene::DefaultSimilarity::tf(double)' /usr/bin/ld: /tmp/ccUJivoA.ltrans35.ltrans.o:(.data.rel.ro+0x588): undefined reference to `Lucene::DefaultSimilarity::idf(int, int)' /usr/bin/ld: /tmp/ccUJivoA.ltrans35.ltrans.o:(.data.rel.ro+0x590): undefined reference to `Lucene::DefaultSimilarity::coord(int, int)' /usr/bin/ld: /tmp/ccUJivoA.ltrans72.ltrans.o:(.data.rel.ro+0x360): undefined reference to `Lucene::DefaultSimilarity::lengthNorm(std::__cxx11::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> > const&, int)' /usr/bin/ld: /tmp/ccUJivoA.ltrans72.ltrans.o:(.data.rel.ro+0x368): undefined reference to `Lucene::DefaultSimilarity::queryNorm(double)' /usr/bin/ld: /tmp/ccUJivoA.ltrans72.ltrans.o:(.data.rel.ro+0x378): undefined reference to `Lucene::DefaultSimilarity::sloppyFreq(int)' /usr/bin/ld: /tmp/ccUJivoA.ltrans72.ltrans.o:(.data.rel.ro+0x380): undefined reference to `Lucene::DefaultSimilarity::tf(double)' /usr/bin/ld: /tmp/ccUJivoA.ltrans72.ltrans.o:(.data.rel.ro+0x398): undefined reference to `Lucene::DefaultSimilarity::idf(int, int)' /usr/bin/ld: /tmp/ccUJivoA.ltrans75.ltrans.o:(.data.rel.ro+0x328): undefined reference to `Lucene::DefaultSimilarity::lengthNorm(std::__cxx11::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> > const&, int)' /usr/bin/ld: /tmp/ccUJivoA.ltrans75.ltrans.o:(.data.rel.ro+0x340): undefined reference to `Lucene::DefaultSimilarity::sloppyFreq(int)' /usr/bin/ld: /tmp/ccUJivoA.ltrans75.ltrans.o:(.data.rel.ro+0x348): undefined reference to `Lucene::DefaultSimilarity::tf(double)' /usr/bin/ld: /tmp/ccUJivoA.ltrans75.ltrans.o:(.data.rel.ro+0x360): undefined reference to `Lucene::DefaultSimilarity::idf(int, int)' /usr/bin/ld: /tmp/ccUJivoA.ltrans75.ltrans.o:(.data.rel.ro+0x368): undefined reference to `Lucene::DefaultSimilarity::coord(int, int)' /usr/bin/ld: /tmp/ccUJivoA.ltrans78.ltrans.o:(.data.rel.ro+0x1d0): undefined reference to `Lucene::DefaultSimilarity::queryNorm(double)' /usr/bin/ld: /tmp/ccUJivoA.ltrans78.ltrans.o:(.data.rel.ro+0x1e0): undefined reference to `Lucene::DefaultSimilarity::sloppyFreq(int)' /usr/bin/ld: /tmp/ccUJivoA.ltrans78.ltrans.o:(.data.rel.ro+0x208): undefined reference to `Lucene::DefaultSimilarity::coord(int, int)' /usr/bin/ld: /tmp/ccUJivoA.ltrans106.ltrans.o:(.data.rel.ro+0x758): undefined reference to `Lucene::DefaultSimilarity::idf(int, int)' /usr/bin/ld: /tmp/ccUJivoA.ltrans109.ltrans.o:(.data.rel.ro+0x4b8): undefined reference to `Lucene::DefaultSimilarity::lengthNorm(std::__cxx11::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> > const&, int)' /usr/bin/ld: /tmp/ccUJivoA.ltrans109.ltrans.o:(.data.rel.ro+0x4c0): undefined reference to `Lucene::DefaultSimilarity::queryNorm(double)' /usr/bin/ld: /tmp/ccUJivoA.ltrans109.ltrans.o:(.data.rel.ro+0x4d0): undefined reference to `Lucene::DefaultSimilarity::sloppyFreq(int)' /usr/bin/ld: /tmp/ccUJivoA.ltrans109.ltrans.o:(.data.rel.ro+0x4d8): undefined reference to `Lucene::DefaultSimilarity::tf(double)' /usr/bin/ld: /tmp/ccUJivoA.ltrans109.ltrans.o:(.data.rel.ro+0x4f0): undefined reference to `Lucene::DefaultSimilarity::idf(int, int)' /usr/bin/ld: /tmp/ccUJivoA.ltrans109.ltrans.o:(.data.rel.ro+0x4f8): undefined reference to `Lucene::DefaultSimilarity::coord(int, int)' /usr/bin/ld: /tmp/ccUJivoA.ltrans114.ltrans.o:(.data.rel.ro+0x320): undefined reference to `Lucene::DefaultSimilarity::lengthNorm(std::__cxx11::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> > const&, int)' /usr/bin/ld: /tmp/ccUJivoA.ltrans114.ltrans.o:(.data.rel.ro+0x328): undefined reference to `Lucene::DefaultSimilarity::queryNorm(double)' /usr/bin/ld: /tmp/ccUJivoA.ltrans114.ltrans.o:(.data.rel.ro+0x340): undefined reference to `Lucene::DefaultSimilarity::tf(double)' /usr/bin/ld: /tmp/ccUJivoA.ltrans114.ltrans.o:(.data.rel.ro+0x358): undefined reference to `Lucene::DefaultSimilarity::idf(int, int)' /usr/bin/ld: /tmp/ccUJivoA.ltrans114.ltrans.o:(.data.rel.ro+0x360): undefined reference to `Lucene::DefaultSimilarity::coord(int, int)' collect2: error: ld returned 1 exit status
make[4]: *** [src/test/CMakeFiles/lucene++-tester.dir/build.make:3876: src/test/lucene++-tester] Error 1 make[4]: Leaving directory '/<<PKGBUILDDIR>>/obj-x86_64-linux-gnu' make[3]: *** [CMakeFiles/Makefile2:805: src/test/CMakeFiles/lucene++-tester.dir/all] Error 2 make[3]: Leaving directory '/<<PKGBUILDDIR>>/obj-x86_64-linux-gnu' make[2]: *** [Makefile:139: all] Error 2
make[2]: Leaving directory '/<<PKGBUILDDIR>>/obj-x86_64-linux-gnu' dh_auto_build: error: cd obj-x86_64-linux-gnu && make -j4 "INSTALL=install --strip-program=true" VERBOSE=1 returned exit code 2 make[1]: *** [debian/rules:14: override_dh_auto_build-indep] Error 25