### PR TITLE
Fix install path for liblucene++.pc

### DIFF
--- a/src/config/core/CMakeLists.txt
+++ b/src/config/core/CMakeLists.txt
@@ -9,7 +9,7 @@ if(NOT WIN32)
   install(
     FILES
       "${CMAKE_CURRENT_BINARY_DIR}/liblucene++.pc"
-    DESTINATION "${LIB_DESTINATION}/pkgconfig")
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 endif()
 
 


### PR DESCRIPTION
Current setting does not work correctly, and `liblucene++.pc` gets installed into includes. Use the same way to set the path which is used for cmake config below, which works as expected.