### PR TITLE
Fix build with boost 1.85.0

### DIFF
--- a/src/core/store/MMapDirectory.cpp
+++ b/src/core/store/MMapDirectory.cpp
@@ -36,7 +36,7 @@ MMapIndexInput::MMapIndexInput(const String& path) {
     bufferPosition = 0;
     if (!path.empty()) {
         try {
-            file.open(boost::filesystem::wpath(path), _length);
+            file.open(boost::filesystem::path(path), _length);
         } catch (...) {
             boost::throw_exception(FileNotFoundException(path));
         }

--- a/src/core/util/FileUtils.cpp
+++ b/src/core/util/FileUtils.cpp
@@ -5,9 +5,9 @@
 /////////////////////////////////////////////////////////////////////////////
 
 #include "LuceneInc.h"
-#include <boost/filesystem/convenience.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
+#include <boost/filesystem/directory.hpp>
 #include "LuceneThread.h"
 #include "StringUtils.h"
 #include "FileUtils.h"
@@ -128,12 +128,12 @@ String joinPath(const String& path, const String& file) {
 }
 
 String extractPath(const String& path) {
-    boost::filesystem::wpath parentPath(path.c_str());
+    boost::filesystem::path parentPath(path.c_str());
     return parentPath.parent_path().wstring().c_str();
 }
 
 String extractFile(const String& path) {
-    boost::filesystem::wpath fileName(path.c_str());
+    boost::filesystem::path fileName(path.c_str());
     return fileName.filename().wstring().c_str();
 }
 


### PR DESCRIPTION
boost::filesystem::wpath has been deprecated (and typedef-ed to boost::filesystem::path) for a long time; it is removed from boost starting with 1.85.0-beta1.

Use boost::filesystem::path instead.

boost/filesystem/convenience.hpp has been removed (and was being included without being used anyway - its only use was indirectly pulling in boost/filesystem/directory.hpp, which is actually used).

Include boost/filesystem/directory.hpp directly instead.