### PR TITLE
Fix compilation with clang-17

### DIFF
--- a/include/lucene++/Collection.h
+++ b/include/lucene++/Collection.h
@@ -167,7 +167,7 @@ public:
     }
 
     void swap(this_type& other) {
-        container.swap(other->container);
+        container.swap(other.container);
     }
 
     TYPE& operator[] (int32_t pos) {

--- a/include/lucene++/Set.h
+++ b/include/lucene++/Set.h
@@ -108,7 +108,7 @@ public:
     }
 
     void swap(this_type& other) {
-        setContainer.swap(other->setContainer);
+        setContainer.swap(other.setContainer);
     }
 
     operator bool() const {


### PR DESCRIPTION
Fixes compilation with clang 17:  apparently, no compiler ever tried to compile `Set<T>::swap()` and `Collection<T>::swap()` because they accidentally used `->` instead of `.`...

