### PR TITLE
Use new Boost.Bind API to fix deprecation warnings

### DIFF
--- a/src/core/search/ParallelMultiSearcher.cpp
+++ b/src/core/search/ParallelMultiSearcher.cpp
@@ -5,7 +5,12 @@
 /////////////////////////////////////////////////////////////////////////////
 
 #include "LuceneInc.h"
+#include <boost/version.hpp>
+#if BOOST_VERSION >= 107300  // Boost 1.73.0+
+#include <boost/bind/bind.hpp>
+#else
 #include <boost/bind.hpp>
+#endif
 #include <boost/bind/protect.hpp>
 #include "ParallelMultiSearcher.h"
 #include "_MultiSearcher.h"

--- a/src/core/util/ThreadPool.cpp
+++ b/src/core/util/ThreadPool.cpp
@@ -5,6 +5,12 @@
 /////////////////////////////////////////////////////////////////////////////
 
 #include "LuceneInc.h"
+#include <boost/version.hpp>
+#if BOOST_VERSION >= 107300  // Boost 1.73.0+
+#include <boost/bind/bind.hpp>
+#else
+#include <boost/bind.hpp>
+#endif
 #include "ThreadPool.h"
 
 namespace Lucene {


### PR DESCRIPTION
Replace deprecated boost/bind.hpp with boost/bind/bind.hpp and use boost::placeholders namespace instead of global placeholders.

This fixes deprecation warnings in Boost 1.73.0 and later versions.


```
In file included from /nix/store/074p1j77fjfk52951r6x3l4kq2i62p67-boost-1.87.0-dev/include/boost/smart_ptr/detail/deprecated_macros.hpp:8,
                 from /nix/store/074p1j77fjfk52951r6x3l4kq2i62p67-boost-1.87.0-dev/include/boost/smart_ptr/detail/sp_counted_base.hpp:22,
                 from /nix/store/074p1j77fjfk52951r6x3l4kq2i62p67-boost-1.87.0-dev/include/boost/smart_ptr/detail/shared_count.hpp:22,
                 from /nix/store/074p1j77fjfk52951r6x3l4kq2i62p67-boost-1.87.0-dev/include/boost/smart_ptr/shared_ptr.hpp:17,
                 from /nix/store/074p1j77fjfk52951r6x3l4kq2i62p67-boost-1.87.0-dev/include/boost/shared_ptr.hpp:17,
                 from /build/source/include/lucene++/Lucene.h:27,
                 from /build/source/src/core/include/LuceneInc.h:23,
                 from /build/source/build/src/core/cotire/lucene++_CXX_prefix.cxx:4,
                 from /build/source/build/src/core/cotire/lucene++_CXX_prefix.hxx:4:
/nix/store/074p1j77fjfk52951r6x3l4kq2i62p67-boost-1.87.0-dev/include/boost/bind.hpp:36:1: note: '#pragma message: The practice of declaring the Bind placeholders (_1, _2, ...) in the global namespace is deprecated. Please use <boost/bind/bind.hpp> + using namespace boost::placeholders, or define BOOST_BIND_GLOBAL_PLACEHOLDERS to retain the current behavior.'
   36 | BOOST_PRAGMA_MESSAGE(
      | ^~~~~~~~~~~~~~~~~~~~
[ 50%] Building CXX object src/
```
