### PR TITLE
Update dependencies.cmake for new boost 1.90 without system-libraries

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -19,7 +19,6 @@ set(lucene_boost_libs
   ${Boost_FILESYSTEM_LIBRARIES}
   ${Boost_IOSTREAMS_LIBRARIES}
   ${Boost_REGEX_LIBRARIES}
-  ${Boost_SYSTEM_LIBRARIES}
   ${Boost_THREAD_LIBRARIES}
 )
 


### PR DESCRIPTION
Also remove Boost_SYSTEM_LIBRARIES, removed in #219