### PR TITLE
Stop io_context before joining threads in ThreadPool destructor

### DIFF
--- a/src/core/util/ThreadPool.cpp
+++ b/src/core/util/ThreadPool.cpp
@@ -30,6 +30,7 @@ ThreadPool::ThreadPool()
 }
 
 ThreadPool::~ThreadPool() {
+    io_context.stop();
     threadGroup.join_all(); // wait for all competition
 }
 


### PR DESCRIPTION
While trying to verify tests previously excluded in Gentoo (https://github.com/gentoo/gentoo/commit/b9d1c7a4bc228ba4750c3207ca24056b73fd6cc3) I noticed that ParallelMultiSearcherTest & SortTest would work, but hang in `~ThreadPool()` on `threadGroup.join_all()`, preventing the test executable from terminating cleanly.
Stopping the io_context makes join_all() work immediately.