### PR TITLE
Fix build error in BitSet getHash when building with MSVC

### DIFF
--- a/src/core/util/BitSet.cpp
+++ b/src/core/util/BitSet.cpp
@@ -233,12 +233,11 @@ int32_t BitSet::hashCode() {
     // Start with a zero hash and use a mix that results in zero if the input is zero.
     // This effectively truncates trailing zeros without an explicit check.
     int64_t hash = 0;
-    to_block_range(bitSet, boost::make_function_output_iterator(
-        [&hash](bitset_type::block_type block) {
-            hash ^= block;
-            hash = (hash << 1) | (hash >> 63); // rotate left
-        }
-    ));
+    auto computeHash = [&hash](bitset_type::block_type block) {
+        hash ^= block;
+        hash = (hash << 1) | (hash >> 63); // rotate left
+    };
+    to_block_range(bitSet, boost::make_function_output_iterator(std::ref(computeHash)));
     // Fold leftmost bits into right and add a constant to prevent empty sets from
     // returning 0, which is too common.
     return (int32_t)((hash >> 32) ^ hash) + 0x98761234;


### PR DESCRIPTION
I noticed the project won’t build on MSVC 19.5 and boost 1.9 due to the getHash function in BitSet.cpp. I believe the issue is that boost::make_function_output_iterator() expects copy assignable. The simplest fix I should be to wrap the lambda in std::ref. This shouldn’t have performance impact. 

I confirmed the project builds on MSVC and all the tests pass with this change