### PR TITLE
Fix crash on corrupt field number in FieldsReader::doc()

### DIFF
--- a/src/core/index/FieldsReader.cpp
+++ b/src/core/index/FieldsReader.cpp
@@ -168,6 +168,10 @@ DocumentPtr FieldsReader::doc(int32_t n, const FieldSelectorPtr& fieldSelector) 
     for (int32_t i = 0; i < numFields; ++i) {
         int32_t fieldNumber = fieldsStream->readVInt();
         FieldInfoPtr fi = fieldInfos->fieldInfo(fieldNumber);
+        if (!fi) {
+            boost::throw_exception(CorruptIndexException(L"invalid field number " + StringUtils::toString(fieldNumber)
+                                                         + L" while reading stored fields for doc " + StringUtils::toString(n)));
+        }
         FieldSelector::FieldSelectorResult acceptField = fieldSelector ? fieldSelector->accept(fi->name) : FieldSelector::SELECTOR_LOAD;
 
         uint8_t bits = fieldsStream->readByte();

--- a/src/test/index/FieldsReaderTest.cpp
+++ b/src/test/index/FieldsReaderTest.cpp
@@ -22,6 +22,8 @@
 #include "IndexReader.h"
 #include "MiscUtils.h"
 #include "FileUtils.h"
+#include "IndexFileNames.h"
+#include "IndexOutput.h"
 
 using namespace Lucene;
 
@@ -376,6 +378,43 @@ public:
     }
 };
 
+}
+
+static void writeCorruptedStoredFieldsIndex(const DirectoryPtr& sourceDir,
+                                            const DirectoryPtr& corruptDir,
+                                            const String& segmentName)
+{
+    String fieldsName = segmentName + L"." + IndexFileNames::FIELDS_EXTENSION();
+    IndexInputPtr in = sourceDir->openInput(fieldsName);
+    ByteArray data(ByteArray::newInstance((int32_t)in->length()));
+    in->readBytes(data.get(), 0, (int32_t)in->length());
+    in->close();
+
+    // Overwrite the first stored field number with an invalid VInt.
+    data[5] = 0x7f;
+    data[6] = 0x7f;
+
+    IndexOutputPtr out = corruptDir->createOutput(fieldsName);
+    out->writeBytes(data.get(), 0, (int32_t)data.size());
+    out->close();
+}
+
+TEST_F(FieldsReaderTest, testCorruptFieldNumber) {
+    String indexDir(FileUtils::joinPath(getTempDir(), L"testfieldreaderbadfieldnumber"));
+    RAMDirectoryPtr sourceDir = newLucene<RAMDirectory>();
+    IndexWriterPtr writer = newLucene<IndexWriter>(sourceDir, newLucene<WhitespaceAnalyzer>(), true, IndexWriter::MaxFieldLengthLIMITED);
+    writer->setUseCompoundFile(false);
+    writer->addDocument(testDoc);
+    writer->close();
+
+    RAMDirectoryPtr corruptDir = newLucene<RAMDirectory>(sourceDir);
+    writeCorruptedStoredFieldsIndex(sourceDir, corruptDir, TEST_SEGMENT_NAME);
+
+    FieldsReaderPtr reader = newLucene<FieldsReader>(corruptDir, TEST_SEGMENT_NAME, fieldInfos);
+    EXPECT_THROW(reader->doc(0, FieldSelectorPtr()), CorruptIndexException);
+    reader->close();
+    sourceDir->close();
+    corruptDir->close();
 }
 
 TEST_F(FieldsReaderTest, testLoadSize) {


### PR DESCRIPTION
FieldsReader::doc() did not validate the field number read from the
stored fields stream. When a corrupted index contained an invalid
field number, the subsequent fieldInfo lookup returned a null pointer,
causing a null-pointer dereference crash.

Throw CorruptIndexException when the field number has no matching
FieldInfo entry. Add a unit test (testCorruptFieldNumber) that
constructs a corrupted fields file with an invalid VInt field number
and verifies the exception is raised.
